### PR TITLE
ETR-64 Feat: 로그인 refreshToken 추가하기

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -15,6 +15,7 @@ import storageSession from 'redux-persist/lib/storage/session'; // sessionStorag
 const persistConfig = {
   key: 'auth',
   storage: storageSession,
+  whitelist: ['accessToken'], // persist할 필드만 명시 (불필요한 필드 방지)
 };
 const persistedAuthReducer = persistReducer(persistConfig, authReducer);
 

--- a/src/components/Signup/AgreementModal.tsx
+++ b/src/components/Signup/AgreementModal.tsx
@@ -38,7 +38,7 @@ function AgreementModal({ isOpen, onClose, title, content, onConfirm }: Agreemen
         <div className="h-64 overflow-y-auto border p-2 mb-4 whitespace-pre-wrap text-sm">
           {content}
         </div>
-         {/* 동의 체크박스 */}
+        {/* 동의 체크박스 */}
         <label className="flex items-center space-x-2 mb-4">
           <input 
             type="checkbox" 
@@ -52,7 +52,7 @@ function AgreementModal({ isOpen, onClose, title, content, onConfirm }: Agreemen
         {/* 오류 메시지 */}
         {showError && <p className="text-rose-500 text-sm mb-2">※동의해야 계속할 수 있습니다.</p>}
 
-         {/* 버튼 */}
+        {/* 버튼 */}
         <div className="text-right space-x-2">
           <button onClick={onClose} className="px-4 py-2 bg-gray-300 rounded">취소</button>
           <button

--- a/src/features/auth/authAPI.ts
+++ b/src/features/auth/authAPI.ts
@@ -1,0 +1,11 @@
+export const refreshAccessToken = async () => {
+  const res = await fetch("http://localhost:8080/api/auth/refresh", {
+    method: "POST",
+    credentials: "include", // 쿠키에 있는 refreshToken을 보냄
+  });
+
+  if (!res.ok) throw new Error("리프레시 실패");
+
+  const result = await res.json();
+  return result.data; // 새로운 accessToken
+};

--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -1,25 +1,22 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from "@reduxjs/toolkit";
 
-interface AuthState {
-  accessToken: string | null;
-}
-
-const initialState: AuthState = {
+const initialState = {
   accessToken: null,
 };
 
 const authSlice = createSlice({
-  name: 'auth',
+  name: "auth",
   initialState,
   reducers: {
-    setAccessToken: (state, action: PayloadAction<string>) => {
+    setAccessToken: (state, action) => {
       state.accessToken = action.payload;
     },
-    clearAccessToken: (state) => {
+    logout: (state) => {
       state.accessToken = null;
+      sessionStorage.removeItem("accessToken");
     },
   },
 });
 
-export const { setAccessToken, clearAccessToken } = authSlice.actions;
+export const { setAccessToken, logout } = authSlice.actions;
 export default authSlice.reducer;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -72,38 +72,46 @@ function Login() {
             <h1 className="text-5xl font-black text-center mb-12">DeepTruth</h1>
 
             {/* ID/PW 입력창 */}
-            <input
-              type="text"
-              placeholder="아이디"
-              value={loginId}
-              onChange={(e) => setLoginId(e.target.value)}
-              className="w-full px-4 py-2 mb-3 border rounded-md focus:outline-none focus:ring"
-            />
-            <div className="relative w-full">
+            {/* enter키로 로그인 */}
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleLogin();
+            }}>
               <input
-                type={showPassword ? "text" : "password"}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="비밀번호"
-                className="w-full px-4 py-2 mb-4 border rounded-md focus:outline-none focus:ring"  />
-              <div
-                className="absolute top-1/3 right-3 transform -translate-y-1/2 cursor-pointer"
-                onClick={() => setShowPassword((prev) => !prev)}>
-                  {showPassword ? <AiOutlineEyeInvisible size={20} /> : <AiOutlineEye size={20} />}
+                type="text"
+                placeholder="아이디"
+                value={loginId}
+                onChange={(e) => setLoginId(e.target.value)}
+                className="w-full px-4 py-2 mb-3 border rounded-md focus:outline-none focus:ring"
+              />
+              <div className="relative w-full">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="비밀번호"
+                  className="w-full px-4 py-2 mb-4 border rounded-md focus:outline-none focus:ring"  />
+                <div
+                  className="absolute top-1/3 right-3 transform -translate-y-1/2 cursor-pointer"
+                  onClick={() => setShowPassword((prev) => !prev)}>
+                    {showPassword ? <AiOutlineEyeInvisible size={20} /> : <AiOutlineEye size={20} />}
+                </div>
               </div>
-            </div>
 
-            {/* ID/PW 버튼 */}
-            <button 
-              onClick={handleLogin}
-              className="w-full bg-green-100 hover:bg-green-500 text-black-100 font-semibold py-2 rounded-md mb-2">
-                로그인
-            </button>
-            <Link to="/signin">
-              <button className="w-full bg-green-200 hover:bg-green-600 text-black-100 font-semibold py-2 rounded-md mb-4">
-                회원가입
+              {/* ID/PW 버튼 */}
+              <button 
+                type="submit"
+                onClick={handleLogin}
+                className="w-full bg-green-100 hover:bg-green-500 text-black-100 font-semibold py-2 rounded-md mb-2">
+                  로그인
               </button>
-            </Link>
+              <Link to="/signin">
+                <button className="w-full bg-green-200 hover:bg-green-600 text-black-100 font-semibold py-2 rounded-md mb-4">
+                  회원가입
+                </button>
+              </Link>
+            </form>
 
             {/* 소셜 로그인 */}
             <div className="max-w-sm w-full mx-auto p-4">  

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -29,12 +29,12 @@ function Login() {
 
   const handleLogin = async () => {
     try {
-      const response = await fetch("http://localhost:8080/api/login", {
+      const response = await fetch("http://localhost:8080/api/auth/login", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        //credentials: "include", // 쿠키 포함 (refreshToken이 쿠키로 온다면 필요)
+        credentials: "include", // 쿠키 포함 (refreshToken이 쿠키로 온다면 필요)
         body: JSON.stringify({ loginId, password }),
       });
 
@@ -45,7 +45,7 @@ function Login() {
         dispatch(setAccessToken(accessToken));
         // 토큰을 전역 상태나 localStorage에 저장 (sessionStorage)
         sessionStorage.setItem("accessToken", accessToken);
-        scheduleAutoLogout(accessToken, dispatch);
+        scheduleAutoLogout(accessToken, dispatch); //자동 만료 예약
 
         // 메인 페이지로 이동
         navigate("/");

--- a/src/pages/Mypage/UserInfo.tsx
+++ b/src/pages/Mypage/UserInfo.tsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "../../app/store"; 
-import { clearAccessToken } from "../../features/auth/authSlice";
+import { logout } from "../../features/auth/authSlice";
 import { useState } from "react";
 import ConfirmModal from "../../components/Modal/ConfirmModal";
 
@@ -13,8 +13,7 @@ function UserInfo() {
   const [showModal, setShowModal] = useState(false);
 
   const handleLogout = () => {
-    dispatch(clearAccessToken());
-    sessionStorage.removeItem("accessToken");
+    dispatch(logout());
     navigate("/");
   };
 

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -66,7 +66,7 @@ function Signin() {
     };
 
     try {
-      const res = await fetch("http://localhost:8080/api/signup", {
+      const res = await fetch("http://localhost:8080/api/auth/signup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -13,7 +13,7 @@ export function parseJwt(token: string): { exp: number } | null {
   }
 }
 
-// accessToken의 만료 시간에 맞춰 자동 로그아웃 또는 자동 갱신 예약
+// accessToken의 만료 시간에 맞춰 refreshToken 호출
 export function scheduleAutoLogout(token: string, dispatch: any) {
   const decoded = parseJwt(token);
   if (!decoded?.exp) return;


### PR DESCRIPTION
## 📝 Summary
> accessToken으로만 구현했던 로그인 방식 accessToken+refreshToken으로 수정하였습니다.

## 💻 Describe your changes
> 동작 방식 (jwt.ts)
1. accessToken을 디코딩해서 exp (만료시간)을 계산
2. 그 만료 시점 5초 전에 setTimeout() 예약
3. 시간 되면:
    - refreshAccessToken() 호출 → 새 accessToken 요청 (보통 refreshToken은 쿠키로 자동 포함됨)
    - 성공하면 → 새 accessToken저장 + scheduleAutoLogout() 다시 예약
    - 실패하면 → 로그아웃 처리 (logout() + 경고 + /login으로 이동)

## #️⃣ Issue number and link
> ex) #28 

## 💬 Message to the Reviewer
>동작방식 괜찮은지 봐주세요!
>
>
