### PR TITLE
ETR-61 Feat: 소셜로그인 구현하기

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -20,34 +20,70 @@ axiosInstance.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+// -------- 응답 인터셉터: 401 → 1회만 리프레시 --------
+let isRefreshing = false;
+let waiters: Array<(t: string) => void> = [];
+const notifyAll = (t: string) => {
+  waiters.forEach((resolve) => resolve(t));
+  waiters = [];
+};
+
 //  응답 인터셉터: accessToken 만료 시 refresh 시도
 axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
+    const status = error?.response?.status;
+
+    // 리프레시 요청 자체가 실패했으면 바로 종료
+    if (originalRequest?.url?.includes("/auth/refresh")) {
+      store.dispatch(logout());
+      sessionStorage.clear();
+      window.location.href = "/login";
+      return Promise.reject(error);
+    }
 
     // accessToken 만료 시 재발급 시도 (401 Unauthorized)
     if (
-      error.response?.status === 401 &&
+      status === 401 &&
       !originalRequest._retry // 무한 루프 방지
     ) {
       originalRequest._retry = true;
 
+      // 이미 누군가 리프레시 중이면 새 토큰 기다렸다가 재시도
+      if (isRefreshing) {
+        const newAT = await new Promise<string>((resolve) => waiters.push(resolve));
+        if (!newAT) {
+          // 리프레시 실패 케이스 전파
+          return Promise.reject(error);
+        }
+        originalRequest.headers.Authorization = `Bearer ${newAT}`;
+        return axiosInstance(originalRequest);
+      }
+
       try {
+        isRefreshing = true;
         // 새 accessToken 발급 시도
         const newAccessToken = await refreshAccessToken();
+        // 상태/스토리지 갱신
         store.dispatch(setAccessToken(newAccessToken));
         sessionStorage.setItem("accessToken", newAccessToken);
 
+        isRefreshing = false;
+        notifyAll(newAccessToken);
+
         // 새 토큰으로 헤더 다시 설정
-        axiosInstance.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
+        //axiosInstance.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
         originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 
         // 원래 요청 다시 시도
         return axiosInstance(originalRequest);
       } catch (refreshError) {
+        isRefreshing = false;
+        notifyAll(""); // 대기중인 요청들에 실패 알림
         // 재발급 실패 → 로그아웃 처리
         store.dispatch(logout());
+        sessionStorage.clear();
         alert("세션이 만료되었습니다. 다시 로그인해주세요.");
         window.location.href = "/login";
         return Promise.reject(refreshError);

--- a/src/api/deepfake.ts
+++ b/src/api/deepfake.ts
@@ -11,7 +11,7 @@ export interface DeepfakeResponse {
 
 export const deepfakeAPI = {
   getAllByUser: async (userId: number) => {
-    const res = await axiosInstance.get("/deepfake", {
+    const res = await axiosInstance.get("/api/deepfake", {
       params: { userId },
     });
     return res.data.data;
@@ -21,19 +21,19 @@ export const deepfakeAPI = {
     formData.append("userId", String(userId));
     formData.append("file", file);
 
-    const res = await axiosInstance.post("/deepfake", formData, {
+    const res = await axiosInstance.post("/api/deepfake", formData, {
       headers: { "Content-Type": "multipart/form-data" },
     });
     return res.data.data;
   },
   getById: async (id: number, userId: number) => {
-    const res = await axiosInstance.get(`/deepfake/${id}`, {
+    const res = await axiosInstance.get(`/api/deepfake/${id}`, {
       params: { userId },
     });
     return res.data.data;
   },
   deleteById: async (id: number, userId: number) => {
-    const res = await axiosInstance.delete(`/deepfake/${id}`, {
+    const res = await axiosInstance.delete(`/api/deepfake/${id}`, {
       params: { userId },
     });
     return res.data;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,11 +1,12 @@
-import { Link, useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { Link, useNavigate, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { setAccessToken, setUser } from "../features/auth/authSlice";
 import { scheduleAutoLogout } from "../utils/jwt";
 import SignupModal from "../components/Modal/SignupModal";
 import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai"; 
 import { api } from "../api";
+import SocialButtons from "./SocialLogin/SocialButtons";
 
 function Login() {
   const [loginId, setLoginId] = useState("");
@@ -15,6 +16,8 @@ function Login() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const navigate = useNavigate();
   const dispatch = useDispatch(); // Redux dispatch
+  const location = useLocation();
+  const errorMessage = location.state?.errorMessage; // 소셜 로그인 실패 메시지
 
   
   const openModal = (msg: string) => {
@@ -57,6 +60,13 @@ function Login() {
       openModal("로그인 중 오류가 발생했습니다.");
     }
   };
+  
+  useEffect(() => {
+    if (errorMessage) {
+      openModal(errorMessage);
+    }
+  }, [errorMessage]);
+
 
 
 
@@ -113,23 +123,7 @@ function Login() {
             <div className="max-w-sm w-full mx-auto p-4">  
               <div className="w-full h-px bg-gray-300"/>
             </div>
-
-            <div className="mt-6 text-center">
-              <p className="text-sm text-gray-500 mb-3">소셜 로그인</p>
-              <div className="flex justify-center gap-4">
-                <Link to="/login/google">
-                <button className="bg-white-100 border border-gray-200 rounded-full p-2 shadow-sm">
-                  <img src="/google-icon.svg" alt="Google" className="w-8 h-8" />
-                </button>
-                </Link>
-                <button className="bg-white-100 border border-gray-200 rounded-full p-2 shadow-sm">
-                  <img src="/naver-icon.svg" alt="Naver" className="w-8 h-8" />
-                </button>
-                <button className="bg-white-100 border border-gray-200 rounded-full p-2 shadow-sm">
-                  <img src="/kakao-icon.svg" alt="Kakao" className="w-8 h-8" />
-                </button>
-              </div>
-            </div>
+            <SocialButtons />
           </div>
         </div>
       </>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,3 @@
-import { IoClose } from "react-icons/io5";
 import { Link, useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { useDispatch } from "react-redux";
@@ -67,9 +66,6 @@ function Login() {
         <div className="flex items-center justify-center min-h-screen">
           {/* 로그인 모달 */}
           <div className=" bg-white-100 rounded-xl p-20 w-full max-w-lg shadow-xl text-black-100">
-            <button className="absolute top-4 right-4 text-gray-900 hover:text-black-100">
-              <IoClose size={20} />
-            </button>
             <h1 className="text-5xl font-black text-center mb-12">DeepTruth</h1>
 
             {/* ID/PW 입력창 */}
@@ -121,9 +117,11 @@ function Login() {
             <div className="mt-6 text-center">
               <p className="text-sm text-gray-500 mb-3">소셜 로그인</p>
               <div className="flex justify-center gap-4">
+                <Link to="/login/google">
                 <button className="bg-white-100 border border-gray-200 rounded-full p-2 shadow-sm">
                   <img src="/google-icon.svg" alt="Google" className="w-8 h-8" />
                 </button>
+                </Link>
                 <button className="bg-white-100 border border-gray-200 rounded-full p-2 shadow-sm">
                   <img src="/naver-icon.svg" alt="Naver" className="w-8 h-8" />
                 </button>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -28,7 +28,7 @@ function Login() {
     if (stateMsg) return stateMsg;
 
     if (error === "session_expired") return "세션이 만료되었습니다. 다시 로그인해주세요.";
-    if (error === "missing_token") return "소셜 로그인에 실패했습니다. 다시 시도해주세요.";
+    //if (error === "missing_token") return "소셜 로그인에 실패했습니다. 다시 시도해주세요.";
     if (error) return "로그인 도중 문제가 발생했습니다. 다시 시도해주세요.";
     return undefined;
   }, [location.state, location.search]);

--- a/src/pages/Mypage/UserInfo.tsx
+++ b/src/pages/Mypage/UserInfo.tsx
@@ -10,6 +10,7 @@ import { api } from "../../api";
 type UserProfile = {
   userId: number;
   loginId: string;
+  name: string;
   nickname: string;
   email: string;
   role: "USER" | "ADMIN";
@@ -52,7 +53,7 @@ function UserInfo() {
         <div className="text-sm w-full space-y-2">
           <div>
             <strong>이름</strong>
-            <p className="text-gray-900 mb-4 mt-2">{user.userId}</p>
+            <p className="text-gray-900 mb-4 mt-2">{user.name}</p>
           </div>
           <div>
             <strong>아이디</strong>

--- a/src/pages/SocialLogin/GoogleLogin.tsx
+++ b/src/pages/SocialLogin/GoogleLogin.tsx
@@ -1,0 +1,5 @@
+import SocialLoginStart from "./SocialLoginStart";
+function GoogleLogin() {
+    return <SocialLoginStart provider="google"/>;
+}
+export default GoogleLogin;

--- a/src/pages/SocialLogin/KakaoLogin.tsx
+++ b/src/pages/SocialLogin/KakaoLogin.tsx
@@ -1,0 +1,5 @@
+import SocialLoginStart from "./SocialLoginStart";
+function KakaoLogin() {
+    return <SocialLoginStart provider="kakao"/>;
+}
+export default KakaoLogin;

--- a/src/pages/SocialLogin/NaverLogin.tsx
+++ b/src/pages/SocialLogin/NaverLogin.tsx
@@ -1,0 +1,5 @@
+import SocialLoginStart from "./SocialLoginStart";
+function NaverLogin() {
+    return <SocialLoginStart provider="naver"/>;
+}
+export default NaverLogin;

--- a/src/pages/SocialLogin/OAuthRedirect.tsx
+++ b/src/pages/SocialLogin/OAuthRedirect.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import { setAccessToken, setUser } from "../../features/auth/authSlice";
@@ -8,11 +8,21 @@ import { api } from "../../api";
 function OAuthRedirect() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const ranRef = useRef(false);
 
   useEffect(() => {
+    if (ranRef.current) return;     //  StrictMode 2회 실행 방지
+    ranRef.current = true;
+
     const params = new URLSearchParams(window.location.search);
-    const accessToken = params.get("accessToken");
-    const refreshToken = params.get("refreshToken");
+    let accessToken = params.get("accessToken");
+    let refreshToken = params.get("refreshToken");
+
+    if (!accessToken || !refreshToken) {
+      // 혹시 첫 실행에서 저장됐는데 쿼리만 사라진 경우 대비
+      accessToken = sessionStorage.getItem("accessToken") || "";
+      refreshToken = sessionStorage.getItem("refreshToken") || "";
+    }
 
     if (!accessToken || !refreshToken) {
       navigate("/login", { 

--- a/src/pages/SocialLogin/OAuthRedirect.tsx
+++ b/src/pages/SocialLogin/OAuthRedirect.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { setAccessToken, setUser } from "../../features/auth/authSlice";
+import { scheduleAutoLogout } from "../../utils/jwt";
+import { api } from "../../api";
+
+export default function OAuthRedirect() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const accessToken = params.get("accessToken");
+    const refreshToken = params.get("refreshToken");
+
+    if (!accessToken || !refreshToken) {
+      navigate("/login?error=missing_token", { replace: true });
+      return;
+    }
+
+    // 1) 토큰 저장 (필요에 따라 localStorage로 교체 가능)
+    sessionStorage.setItem("accessToken", accessToken);
+    sessionStorage.setItem("refreshToken", refreshToken);
+    dispatch(setAccessToken(accessToken));
+    scheduleAutoLogout(accessToken, dispatch);
+
+    // 2) URL에서 토큰 제거 (노출 최소화)
+    window.history.replaceState({}, "", "/oauth2/redirect");
+
+    // 3) 유저 프로필 호출 → 상태 저장
+    (async () => {
+      try {
+        const userInfo = await api.user.getProfile(); // Authorization 헤더는 axios 인터셉터에서 주입
+        dispatch(setUser(userInfo));
+        sessionStorage.setItem("user", JSON.stringify(userInfo));
+        navigate("/", { replace: true }); // 원하는 랜딩 경로로 변경 가능
+      } catch (e) {
+        console.error("Failed to load profile:", e);
+        navigate("/login?error=profile_load_failed", { replace: true });
+      }
+    })();
+  }, [dispatch, navigate]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold mb-2">로그인 처리 중…</h2>
+        <p className="text-gray-500">계정 정보를 불러오고 있습니다.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SocialLogin/OAuthRedirect.tsx
+++ b/src/pages/SocialLogin/OAuthRedirect.tsx
@@ -5,7 +5,7 @@ import { setAccessToken, setUser } from "../../features/auth/authSlice";
 import { scheduleAutoLogout } from "../../utils/jwt";
 import { api } from "../../api";
 
-export default function OAuthRedirect() {
+function OAuthRedirect() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
@@ -15,7 +15,10 @@ export default function OAuthRedirect() {
     const refreshToken = params.get("refreshToken");
 
     if (!accessToken || !refreshToken) {
-      navigate("/login?error=missing_token", { replace: true });
+      navigate("/login", { 
+        replace: true,
+        state: { errorMessage: "소셜 로그인에 실패했습니다. 다시 시도해주세요."},
+      });
       return;
     }
 
@@ -34,7 +37,7 @@ export default function OAuthRedirect() {
         const userInfo = await api.user.getProfile(); // Authorization 헤더는 axios 인터셉터에서 주입
         dispatch(setUser(userInfo));
         sessionStorage.setItem("user", JSON.stringify(userInfo));
-        navigate("/", { replace: true }); // 원하는 랜딩 경로로 변경 가능
+        navigate("/", { replace: true });
       } catch (e) {
         console.error("Failed to load profile:", e);
         navigate("/login?error=profile_load_failed", { replace: true });
@@ -46,8 +49,9 @@ export default function OAuthRedirect() {
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center">
         <h2 className="text-2xl font-bold mb-2">로그인 처리 중…</h2>
-        <p className="text-gray-500">계정 정보를 불러오고 있습니다.</p>
+        <p className="text-gray-900">계정 정보를 불러오고 있습니다.</p>
       </div>
     </div>
   );
 }
+export default OAuthRedirect;

--- a/src/pages/SocialLogin/OAuthRedirect.tsx
+++ b/src/pages/SocialLogin/OAuthRedirect.tsx
@@ -22,7 +22,7 @@ function OAuthRedirect() {
       return;
     }
 
-    // 1) 토큰 저장 (필요에 따라 localStorage로 교체 가능)
+    // 1) 토큰 저장 
     sessionStorage.setItem("accessToken", accessToken);
     sessionStorage.setItem("refreshToken", refreshToken);
     dispatch(setAccessToken(accessToken));
@@ -40,7 +40,7 @@ function OAuthRedirect() {
         navigate("/", { replace: true });
       } catch (e) {
         console.error("Failed to load profile:", e);
-        navigate("/login?error=profile_load_failed", { replace: true });
+        navigate("/login", { replace: true });
       }
     })();
   }, [dispatch, navigate]);

--- a/src/pages/SocialLogin/SocialButtons.tsx
+++ b/src/pages/SocialLogin/SocialButtons.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+
+export default function SocialButtons() {
+  return (
+    <div className="mt-6 text-center">
+      <p className="text-sm text-gray-500 mb-3">소셜 로그인</p>
+        <div className="flex justify-center gap-4">
+          <Link to="/login/google">
+            <button className="bg-white-100 border border-gray-200 rounded-full p-2 shadow-sm">
+              <img src="/google-icon.svg" alt="Google" className="w-8 h-8" />
+            </button>
+          </Link>
+          <Link to="/login/naver">
+            <button className="bg-white-100 border border-gray-200 rounded-full p-2 shadow-sm">
+              <img src="/naver-icon.svg" alt="Naver" className="w-8 h-8" />
+            </button>
+          </Link>
+          <Link to="/login/kakao">
+            <button className="bg-white-100 border border-gray-200 rounded-full p-2 shadow-sm">
+              <img src="/kakao-icon.svg" alt="Kakao" className="w-8 h-8" />
+            </button>
+          </Link>
+        </div>
+      </div>
+  );
+}

--- a/src/pages/SocialLogin/SocialLoginStart.tsx
+++ b/src/pages/SocialLogin/SocialLoginStart.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+type Provider = "google" | "naver" | "kakao";
+
+interface Props {
+  provider: Provider;
+  backendBaseUrl?: string; // 기본값 localhost:8080
+}
+
+/**
+ * 마운트 시 해당 provider의 /oauth2/authorization/{provider}로 즉시 리다이렉트
+ * 필요하면 버튼 클릭형으로 바꿔도 됨.
+ */
+export default function SocialLoginStart({
+  provider,
+  backendBaseUrl = "http://localhost:8080",
+}: Props) {
+  useEffect(() => {
+    // state 값 붙이고 싶으면 여기서 생성해서 쿼리에 추가 가능
+    window.location.href = `${backendBaseUrl}/oauth2/authorization/${provider}`;
+  }, [provider, backendBaseUrl]);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="text-center">
+        <h2 className="text-2xl font-bold mb-2">소셜 로그인 진행 중…</h2>
+        <p className="text-gray-500">잠시만 기다려주세요. {provider}로 이동합니다.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SocialLogin/SocialLoginStart.tsx
+++ b/src/pages/SocialLogin/SocialLoginStart.tsx
@@ -7,11 +7,10 @@ interface Props {
   backendBaseUrl?: string; // 기본값 localhost:8080
 }
 
-/**
+/*
  * 마운트 시 해당 provider의 /oauth2/authorization/{provider}로 즉시 리다이렉트
- * 필요하면 버튼 클릭형으로 바꿔도 됨.
  */
-export default function SocialLoginStart({
+function SocialLoginStart({
   provider,
   backendBaseUrl = "http://localhost:8080",
 }: Props) {
@@ -24,8 +23,9 @@ export default function SocialLoginStart({
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center">
         <h2 className="text-2xl font-bold mb-2">소셜 로그인 진행 중…</h2>
-        <p className="text-gray-500">잠시만 기다려주세요. {provider}로 이동합니다.</p>
+        <p className="text-gray-900">잠시만 기다려주세요. {provider}로 이동합니다.</p>
       </div>
     </div>
   );
 }
+export default SocialLoginStart;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -2,6 +2,10 @@ import { createBrowserRouter } from "react-router-dom";
 import Home from "../pages/Home/Home";
 import Signin from "../pages/Signin";
 import Login from "../pages/Login";
+import GoogleLogin from "../pages/SocialLogin/GoogleLogin";
+import OAuthRedirect from "../pages/SocialLogin/OAuthRedirect";
+import NaverLogin from "../pages/SocialLogin/NaverLogin";
+import KakaoLogin from "../pages/SocialLogin/KakaoLogin";
 import Features from "../pages/Features";
 import MyPage from "../pages/Mypage/MyPage";
 import PwCheck from "../pages/Mypage/PwCheck"
@@ -20,8 +24,7 @@ import InsertLoading from "../components/InsertLoading";
 import DetectionReport from "../pages/Deepfake/DetectionReport";
 import WatermarkReport from "../pages/Watermark/WatermarkReport";
 import NoiseResult from "../pages/AdversarialNoise/NoiseResult";
-import GoogleLogin from "../pages/SocialLogin/GoogleLogin";
-import OAuthRedirect from "../pages/SocialLogin/OAuthRedirect";
+
 
 const Router = createBrowserRouter([
   {
@@ -46,6 +49,14 @@ const Router = createBrowserRouter([
       {
         path: '/login/google',
         element: <GoogleLogin />
+      },
+      {
+        path: '/login/naver',
+        element: <NaverLogin />
+      },
+      {
+        path: '/login/kakao',
+        element: <KakaoLogin />
       },
       {
         path: '/oauth2/redirect',

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -20,6 +20,8 @@ import InsertLoading from "../components/InsertLoading";
 import DetectionReport from "../pages/Deepfake/DetectionReport";
 import WatermarkReport from "../pages/Watermark/WatermarkReport";
 import NoiseResult from "../pages/AdversarialNoise/NoiseResult";
+import GoogleLogin from "../pages/SocialLogin/GoogleLogin";
+import OAuthRedirect from "../pages/SocialLogin/OAuthRedirect";
 
 const Router = createBrowserRouter([
   {
@@ -40,6 +42,14 @@ const Router = createBrowserRouter([
       {
         path: '/login',
         element: <Login />
+      },
+      {
+        path: '/login/google',
+        element: <GoogleLogin />
+      },
+      {
+        path: '/oauth2/redirect',
+        element: <OAuthRedirect />
       },
       {
         path: '/features',

--- a/src/utils/RefreshManager.ts
+++ b/src/utils/RefreshManager.ts
@@ -1,0 +1,50 @@
+import { store } from "../app/store";
+import { setAccessToken, logout } from "../features/auth/authSlice";
+import { refreshAccessToken } from "../features/auth/authAPI";
+
+/**
+ * 공용 리프레시 매니저:
+ * - 동시에 여러 군데서 호출돼도 refresh는 딱 1번만 수행
+ * - 성공 시 모든 호출자에게 같은 Promise 결과 공유
+ * - 실패 시 세션 정리
+ */
+let refreshing = false;
+let inFlight: Promise<string> | null = null;
+
+export async function ensureFreshAccessToken(): Promise<string> {
+  // 이미 accessToken이 있으면 우선 반환
+  const current = sessionStorage.getItem("accessToken");
+  if (current) return current;
+
+  // 누군가 이미 리프레시 중이면 그 Promise를 그대로 기다림
+  if (refreshing && inFlight) return inFlight;
+
+  // 내가 리프레시 수행
+  refreshing = true;
+  inFlight = (async () => {
+    try {
+      // 서버로 /auth/refresh 호출
+      const newAT = await refreshAccessToken(); // string
+      // 저장/상태 갱신
+      sessionStorage.setItem("accessToken", newAT);
+      store.dispatch(setAccessToken(newAT));
+      return newAT;
+    } finally {
+      refreshing = false;
+      inFlight = null;
+    }
+  })();
+
+  try {
+    return await inFlight;
+  } catch (e) {
+    // 실패 → 세션 정리
+    store.dispatch(logout());
+    sessionStorage.clear();
+    throw e;
+  }
+}
+
+export function isRefreshOngoing() {
+  return refreshing;
+}

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,11 +1,15 @@
 import { logout, setAccessToken } from "../features/auth/authSlice";
-import { refreshAccessToken } from "../features/auth/authAPI";
+import { ensureFreshAccessToken } from "./RefreshManager";
+
+let timerId: ReturnType<typeof setTimeout> | null = null;
 
 // 토큰을 디코딩하여 만료 시간 추출
 export function parseJwt(token: string): { exp: number } | null {
   try {
     const base64Url = token.split('.')[1];
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    if (!base64Url) return null;
+    let base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    while (base64.length % 4 !== 0) base64 += "="; // padding fix
     const json = atob(base64);
     return JSON.parse(json);
   } catch (e) {
@@ -14,22 +18,28 @@ export function parseJwt(token: string): { exp: number } | null {
 }
 
 // accessToken의 만료 시간에 맞춰 refreshToken 호출
+/**
+ * 만료 5초 전 선제 갱신. (성공 시 새 토큰으로 재예약)
+ * 실패 시 세션 정리 + /login?error=session_expired 로 이동
+ */
 export function scheduleAutoLogout(token: string, dispatch: any) {
   const decoded = parseJwt(token);
   if (!decoded?.exp) return;
 
   const timeout = decoded.exp * 1000 - Date.now() - 5000; // 5초 여유 줌
+  if (timerId) clearTimeout(timerId);
 
   if (timeout > 0) {
-    setTimeout(async () => {
+    timerId = setTimeout(async () => {
       try {
-        const newAccessToken = await refreshAccessToken(); // 새 토큰 발급 시도
+        const newAccessToken = await ensureFreshAccessToken(); // 새 토큰 발급 시도
         dispatch(setAccessToken(newAccessToken));
         sessionStorage.setItem("accessToken", newAccessToken);
         scheduleAutoLogout(newAccessToken, dispatch); // 새 토큰으로 재예약
       } catch (e) {
         dispatch(logout());
         //alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        sessionStorage.clear();
         window.location.href = "/login?error=session_expired";
       }
     }, timeout);
@@ -37,6 +47,12 @@ export function scheduleAutoLogout(token: string, dispatch: any) {
     // 이미 만료된 경우 바로 로그아웃 처리
     dispatch(logout());
     //alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+    sessionStorage.clear();
     window.location.href = "/login?error=session_expired";
   }
+}
+// 로그아웃 시 타이머 해제용
+export function cancelAutoLogout() {
+  if (timerId) clearTimeout(timerId);
+  timerId = null;
 }

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -29,14 +29,14 @@ export function scheduleAutoLogout(token: string, dispatch: any) {
         scheduleAutoLogout(newAccessToken, dispatch); // 새 토큰으로 재예약
       } catch (e) {
         dispatch(logout());
-        alert("세션이 만료되었습니다. 다시 로그인해주세요.");
-        window.location.href = "/login";
+        //alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+        window.location.href = "/login?error=session_expired";
       }
     }, timeout);
   } else {
     // 이미 만료된 경우 바로 로그아웃 처리
     dispatch(logout());
-    alert("세션이 만료되었습니다. 다시 로그인해주세요.");
-    window.location.href = "/login";
+    //alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+    window.location.href = "/login?error=session_expired";
   }
 }


### PR DESCRIPTION
## 📝 Summary
> 카카오, 네이버, 구글 소셜 로그인 구현했습니다.

## 💻 Describe your changes
> 일반로그인과 동일하게 Jwt 이용하여 accessToken, refreshToken 구조로 구현했습니다.
토큰은 sessionStorage에 저장해놓았고 유저프로필 연결한 뒤 유저정보도 동일하게 sessionStorage에 저장했습니다.
> 소셜로그인 흐름
 1. **프론트 → 백엔드** `/oauth2/authorization/google`
2. **백엔드 → 구글** (로그인 화면)
3. 구글 로그인 완료 후 **구글 → 백엔드** (`/login/oauth2/code/google`)
4. 백엔드가 토큰 발급 후 **프론트로 리디렉션**: http://localhost:5173/oauth2/redirect?accessToken=...&refreshToken=...
5. 프론트 `/oauth2/redirect`에서 토큰 파싱 → 저장 → 프로필 조회 → 홈으로 이동
6. 이후 API는 `Authorization: Bearer {accessToken}`

>axiosInstance.tsx 리펙토링했습니다.
1. 동시 401 리프레시 중복 호출 방지(single‑flight)
2. 토큰 소스 우선순위(sessionStorage → store 순으로 읽기)
3. 리프레시 자체 401/네트워크 에러 분기

>공용 리프레시 매니저 생성하였습니다.
utils>RefreshManager.tsx
- 동시에 여러 군데서 호출돼도 refresh는 딱 1번만 수행
- 성공 시 모든 호출자에게 같은 Promise 결과 공유
- 실패 시 세션 정리

## #️⃣ Issue number and link
> #25 

## 💬 Message to the Reviewer
> 네이버 로그인 테스트는 배포 후에 진행하겠습니다.

