### PR TITLE
ETR-85 Feat: 적대적 노이즈 기록 조회&삭제 구현

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,10 +2,12 @@ import { userAPI } from "./user";
 import { authAPI } from "./auth";
 import { deepfakeAPI } from "./deepfake";
 import { watermarkAPI } from "./watermark";
+import { noiseAPI } from "./noise"
 
 export const api = {
   user: userAPI,
   auth: authAPI,
   deepfake: deepfakeAPI,
-  watermark: watermarkAPI
+  watermark: watermarkAPI,
+  noise: noiseAPI
 };

--- a/src/api/noise.ts
+++ b/src/api/noise.ts
@@ -1,0 +1,26 @@
+import axiosInstance from "./axiosInstance";
+
+export interface NoiseResponse {
+    noiseId: number;
+    originalFilePath: string;
+    processedFilePath: string;
+    epsilon: number;
+    createdAt: string;
+}
+
+export const noiseAPI = {
+    getAllByUser: async (page = 0, size = 15, sort = "createdAt,desc") => {
+      const res = await axiosInstance.get("/api/noise/history", {
+        params: { page, size, sort },
+      });
+      return res.data.data;
+    },
+    getById: async (id: number) => {
+      const res = await axiosInstance.get(`/api/noise/${id}`);
+      return res.data.data;
+    },
+    deleteById: async (id: number) => {
+    const res = await axiosInstance.delete(`/api/noise/${id}`);
+    return res.data;
+    }
+}

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -9,7 +9,7 @@ const ConfirmModal = ({ message, buttonmessage, onConfirm, onCancel }: ConfirmMo
   return (
     <div className="fixed inset-0 bg-black-100 bg-opacity-40 flex items-center justify-center z-50">
       <div className="bg-white-100 p-6 rounded-lg w-80 shadow-lg text-center">
-        <p className="text-lg font-semibold mb-4 text-black-100 whitespace-pre-line">{message}</p>
+        <p className="text-lg font-semibold mb-4 text-black-100 whitespace-pre-line">{(message ?? '').replace(/\\n/g, '\n')}</p>
         <div className="flex justify-center gap-4">
           <button
             onClick={onCancel}

--- a/src/components/Mypage/RecordPage.tsx
+++ b/src/components/Mypage/RecordPage.tsx
@@ -30,10 +30,10 @@ function RecordPage({ title, records, onAddClick, showDownloadButton = true, onI
 
     {/* List */}
         <ul className="space-y-10">
-          {records.length === 0 ? (
+         {/*  {records.length === 0 ? (
             <li className="text-gray-900 text-center text-lg mt-10">기록이 없습니다.</li>
-          ) : (
-            records.map((record) => (
+          ) : (*/}
+            {records.map((record) => (
               <li key={record.id} className="flex items-center space-x-4">
                 <img src={record.img}   alt={record.name} className="w-20 h-20 rounded-full object-cover" />
                 <div className="flex-1">
@@ -53,7 +53,7 @@ function RecordPage({ title, records, onAddClick, showDownloadButton = true, onI
                 </div>
               </li>
             ))
-          )}
+          }
         </ul>
       </div>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -28,25 +28,13 @@ function Navbar({ navOpen, setNavOpen }: NavProps) {
           ) : (
             <Link to="login" onClick={() => setNavOpen(!navOpen)}>딥페이크 탐지</Link>
           )}
-          {accessToken ? (
-            <Link to="/adversarial-noise" onClick={() => setNavOpen(!navOpen)}>적대적 노이즈 삽입</Link>
-          ) : (
-            <Link to="login" onClick={() => setNavOpen(!navOpen)}>적대적 노이즈 삽입</Link>
-          )}
+          <Link to="/adversarial-noise" onClick={() => setNavOpen(!navOpen)}>적대적 노이즈 삽입</Link>
           <div>
             <button onClick={() => setWatermarkOpen(!watermarkOpen)}>디지털 워터마킹</button>
             { watermarkOpen && (
               <div className="flex flex-col text-[40px]">
-                {accessToken ? (
-                  <Link to="/watermark-insert" onClick={() => setNavOpen(!navOpen)}>삽입</Link>
-                ) : (
-                  <Link to="login" onClick={() => setNavOpen(!navOpen)}>삽입</Link>
-                )}
-                {accessToken ? (
-                  <Link to="/watermark-detection" onClick={() => setNavOpen(!navOpen)}>탐지</Link>
-                ) : (
-                  <Link to="login" onClick={() => setNavOpen(!navOpen)}>탐지</Link>
-                )}
+                <Link to="/watermark-insert" onClick={() => setNavOpen(!navOpen)}>삽입</Link>
+                <Link to="/watermark-detection" onClick={() => setNavOpen(!navOpen)}>탐지</Link>
               </div>
             )}
           </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -28,13 +28,25 @@ function Navbar({ navOpen, setNavOpen }: NavProps) {
           ) : (
             <Link to="login" onClick={() => setNavOpen(!navOpen)}>딥페이크 탐지</Link>
           )}
-          <Link to="/adversarial-noise" onClick={() => setNavOpen(!navOpen)}>적대적 노이즈 삽입</Link>
+          {accessToken ? (
+            <Link to="/adversarial-noise" onClick={() => setNavOpen(!navOpen)}>적대적 노이즈 삽입</Link>
+          ) : (
+            <Link to="login" onClick={() => setNavOpen(!navOpen)}>적대적 노이즈 삽입</Link>
+          )}
           <div>
             <button onClick={() => setWatermarkOpen(!watermarkOpen)}>디지털 워터마킹</button>
             { watermarkOpen && (
               <div className="flex flex-col text-[40px]">
-                <Link to="/watermark-insert" onClick={() => setNavOpen(!navOpen)}>삽입</Link>
-                <Link to="/watermark-detection" onClick={() => setNavOpen(!navOpen)}>탐지</Link>
+                {accessToken ? (
+                  <Link to="/watermark-insert" onClick={() => setNavOpen(!navOpen)}>삽입</Link>
+                ) : (
+                  <Link to="login" onClick={() => setNavOpen(!navOpen)}>삽입</Link>
+                )}
+                {accessToken ? (
+                  <Link to="/watermark-detection" onClick={() => setNavOpen(!navOpen)}>탐지</Link>
+                ) : (
+                  <Link to="login" onClick={() => setNavOpen(!navOpen)}>탐지</Link>
+                )}
               </div>
             )}
           </div>

--- a/src/components/Report/DeepfakeReport.tsx
+++ b/src/components/Report/DeepfakeReport.tsx
@@ -1,5 +1,7 @@
 import { PieChart, Pie, Cell, Label } from "recharts";
 import ReportNotice from "./ReportNotice";
+import { IoClose } from "react-icons/io5";
+import { useNavigate } from "react-router-dom";
 
 const COLORS = ["#3D3D42", "#FFFFFF"]; // gray, white
 
@@ -22,6 +24,8 @@ function DeepfakeReport({ result, createdAt }: Props) {
   const maxConfidence = result?.maxConfidence ?? 0;
   const suspectImage = result?.filePath ?? null;
 
+  const navigate = useNavigate();
+
   const data = [
     { name: "Fake", value: fake },
     { name: "Real", value: real },
@@ -33,8 +37,17 @@ function DeepfakeReport({ result, createdAt }: Props) {
   else if (fake <= 80) message = "딥페이크 가능성이 높음";
   else message = "딥페이크 가능성이 매우 높음";
 
+  const handleClose = () => {
+    navigate(-1); // 이전 페이지로 이동
+  }
+
   return (
-    <div className="min-h-screen px-20 py-10 mx-20">
+    <div className="relative min-h-screen px-20 py-10 mx-20">
+      <button 
+        onClick={handleClose}
+        className="absolute top-4 right-1 text-white-100 hover:text-gray-50">
+          <IoClose size={30} />
+      </button>
       {/* 헤더 */}
       <div className="bg-white-200 p-6 rounded-xl mb-6">
         <h2 className="text-3xl font-semibold mb-3">딥페이크 탐지</h2>

--- a/src/components/Report/WatermarkSuccessReport.tsx
+++ b/src/components/Report/WatermarkSuccessReport.tsx
@@ -23,7 +23,7 @@ function WatermarkSuccessReport({ result, confirmMessage }: Props) {
       const blob = await res.blob();
       const link = document.createElement("a");
       link.href = window.URL.createObjectURL(blob);;
-      link.download = `${filename}`;
+      link.download = filename;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/src/components/Report/WatermarkSuccessReport.tsx
+++ b/src/components/Report/WatermarkSuccessReport.tsx
@@ -1,3 +1,6 @@
+import { IoClose } from "react-icons/io5";
+import { useNavigate } from "react-router-dom";
+
 type Props={
   result: {
     s3WatermarkedKey: string;
@@ -9,6 +12,7 @@ type Props={
 
 function WatermarkSuccessReport({ result, confirmMessage }: Props) {
 
+  const navigate = useNavigate();
   const image = result?.s3WatermarkedKey ?? null;
   console.log(image);
   const filename = result?.fileName ?? null;
@@ -34,8 +38,17 @@ function WatermarkSuccessReport({ result, confirmMessage }: Props) {
     }
   }
 
+  const handleClose = () => {
+    navigate(-1); // 이전 페이지로 이동
+  }
+
   return(
-    <div className="w-full h-full flex flex-col justify-center items-center gap-7 text-white-100">
+    <div className="relative w-full h-full flex flex-col justify-center items-center gap-7 text-white-100">
+      <button 
+        onClick={handleClose}
+        className="absolute top-4 right-4 text-white-100 hover:text-gray-50">
+          <IoClose size={30} />
+      </button>
       {image ? (
         <div className="flex mt-8">
           <img

--- a/src/components/Upload/deepfake/DeepfakeSetting.tsx
+++ b/src/components/Upload/deepfake/DeepfakeSetting.tsx
@@ -3,7 +3,7 @@ import ModeSelector from './ModeSelector';
 import OptionsPanel from './OptionPanel';
 import { DetectionOptions, Mode } from './DetectionOptions';
 
-const defaultOptions: DetectionOptions = { //세부모드 기존 기본세팅
+const defaultOptions: DetectionOptions = { //정밀모드 기존 기본세팅
   use_tta: true,
   use_illum: true,
   smooth_window: 5,
@@ -31,7 +31,7 @@ function DeepfakeSettings({ onChange }: DeepfakeSettingsProps) {
         <ModeSelector value={mode} onChange={setMode} />
       </div>
 
-      {/* 세부모드일 때만 옵션 보이기 */}
+      {/* 정밀모드일 때만 옵션 보이기 */}
       {mode === 'advanced' && (
         <OptionsPanel value={opts} onChange={setOpts} />
       )}

--- a/src/components/Upload/deepfake/ModeSelector.tsx
+++ b/src/components/Upload/deepfake/ModeSelector.tsx
@@ -44,7 +44,7 @@ function ModeSelector({ value, onChange }: ModeSelectorProps) {
           }`}
           aria-hidden
         />
-        <span className="text-3xl font-semibold">세부모드</span>
+        <span className="text-3xl font-semibold">정밀모드</span>
         {value === 'advanced' && (
           <span className="ml-1 text-[10px] px-1.5 py-0.5 rounded bg-emerald-100 text-green-200">ON</span>
         )}

--- a/src/pages/AdversarialNoise/AdversarialNoise.tsx
+++ b/src/pages/AdversarialNoise/AdversarialNoise.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import FileUploadPage from "../../components/Upload/FileUploadPage";
 import { postNoiseImage } from "../../api/noise_api";
 import { useNavigate } from "react-router-dom";
@@ -11,6 +11,12 @@ function AdversarialNoise() {
   const navigate = useNavigate();
 
   const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken);
+
+  useEffect(() => {
+      if (!isLoggedIn) {
+        navigate("/login");
+      }
+  }, [isLoggedIn, navigate]);
 
   const handleNoiseInsert = async () => {
     try {

--- a/src/pages/Deepfake/Detection.tsx
+++ b/src/pages/Deepfake/Detection.tsx
@@ -53,7 +53,8 @@ function Detection() {
       
     } catch (error: any) {
       console.error("업로드/예측 중 오류:", error);
-      alert("서버 오류로 인해 업로드에 실패했습니다.\n" + (error.response?.data?.message || error.message));
+      console.log(error.response?.data?.message || error.message);
+      alert("서버 오류로 인해 업로드에 실패했습니다.");
       navigate("/pages/NotFound")
     }
     

--- a/src/pages/Deepfake/Detection.tsx
+++ b/src/pages/Deepfake/Detection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState,useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
@@ -35,6 +35,13 @@ function Detection() {
 
   const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken);  // 로그인 여부만 확인(토큰은 axiosInstance 인터셉터가 알아서 처리)
   console.log("isLoggedIn", isLoggedIn);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      navigate("/login");
+    }
+  }, [isLoggedIn, navigate]);
+
 
   const handleDetectionInsert = async() => {
     if (!file || !isLoggedIn) {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import SignupModal from "../components/Modal/SignupModal";
 import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai"; 
 import { api } from "../api";
 import SocialButtons from "./SocialLogin/SocialButtons";
+import axios from "axios";
 
 function Login() {
   const [loginId, setLoginId] = useState("");
@@ -54,10 +55,19 @@ function Login() {
   };
 
   const handleLogin = async () => {
+    // 1) 프론트 선검증 (즉시 리턴)
+    if (!loginId.trim()) {
+      openModal("아이디를 입력해주세요.");
+      return;
+    }
+    if (!password.trim()) {
+      openModal("비밀번호를 입력해주세요.");
+      return;
+    }
     try {
       const result = await api.auth.login(loginId, password);
 
-      if (result.success) {
+      if (result?.success) {
         const accessToken = result.data.accessToken;
         const refreshToken = result.data.refreshToken;
         // 전역 Redux 상태에 저장
@@ -76,11 +86,18 @@ function Login() {
         // 메인 페이지로 이동
         navigate("/");
       } else {
-        openModal(result.message || "로그인 실패");
+        openModal(result?.message || "로그인 실패");
       }
-    } catch (err) {
-      console.error("Login error:", err);
-      openModal("로그인 중 오류가 발생했습니다.");
+    } catch (err: unknown) {
+        if (axios.isAxiosError(err)){
+          const serverMsg = 
+            err.response?.data?.message
+          openModal(serverMsg || "로그인 중 오류가 발생했습니다.");
+        } else {
+          console.error("Login error:", err);
+          openModal("로그인 중 오류가 발생했습니다.");
+        }
+     
     }
   };
   

--- a/src/pages/Mypage/MyPage.tsx
+++ b/src/pages/Mypage/MyPage.tsx
@@ -1,12 +1,36 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from "react-router-dom";
 import UserInfo from './UserInfo';
-import RecordPage from '../../components/Mypage/RecordPage';
 import DeepfakePanel from './Panel/DeepfakePanel';
 import NoisePanel from './Panel/NoisePanel';
 import WatermarkPanel from './Panel/WatermarkPanel';
 
+type Tab = "deepfake" | "noise" | "watermark";
+
 function MyPage() {
-  const [activeTab, setActiveTab] = useState('deepfake');
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // URL(tab) → 세션스토리지 → 기본값 순으로 초기 탭 결정
+  const initialTab = useMemo<Tab>(() => {
+    const fromUrl = searchParams.get("tab") as Tab | null;
+    if (fromUrl === "deepfake" || fromUrl === "noise" || fromUrl === "watermark") {
+      return fromUrl;
+    }
+    const fromSS = sessionStorage.getItem("mypage.tab") as Tab | null;
+    return (fromSS === "deepfake" || fromSS === "noise" || fromSS === "watermark")
+      ? fromSS
+      : "deepfake";
+  }, [searchParams]);
+
+  const [activeTab, setActiveTab] = useState<Tab>(initialTab);
+
+  // 탭 변경 시 URL과 세션스토리지에 동기화
+  useEffect(() => {
+    sessionStorage.setItem("mypage.tab", activeTab);
+    setSearchParams({ tab: activeTab }, { replace: true });
+  }, [activeTab, setSearchParams]);
+
 
     const renderTabContent = () => {
     switch (activeTab) {

--- a/src/pages/Mypage/Panel/DeepfakePanel.tsx
+++ b/src/pages/Mypage/Panel/DeepfakePanel.tsx
@@ -28,7 +28,7 @@ function DeepfakePanel() {
   useEffect(() => {
     if (!isLoggedIn) {
       setLoading(false);
-      setError("로그인이 필요합니다.");
+      //setError("로그인이 필요합니다.");
       return;
     }
     (async () => {
@@ -118,6 +118,9 @@ function DeepfakePanel() {
       {/* 에러/로딩 상태 메시지 (리스트 아래에 보여짐) */}
       {loading && (
         <p className="text-center mt-4 text-gray-900">불러오는 중...</p>
+      )}
+      {!loading && records.length === 0 && (
+        <p className="text-gray-900 text-center text-lg mt-10">기록이 없습니다.</p>
       )}
       {!loading && error && (
         <p className="text-center mt-4 text-red-500">{error}</p>

--- a/src/pages/Mypage/Panel/NoisePanel.tsx
+++ b/src/pages/Mypage/Panel/NoisePanel.tsx
@@ -1,22 +1,98 @@
 import RecordPage from "../../../components/Mypage/RecordPage";
+import ConfirmModal from "../../../components/Modal/ConfirmModal";
 import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "../../../app/store";
+import { api } from "../../../api";
 
-const noiseRecords = [
-    { id: 4, name: '적대적 노이즈 04', date: '2025. 3. 21. 금요일', img: '/img/user4.jpg' },
-    { id: 3, name: '적대적 노이즈 03', date: '2025. 3. 21. 금요일', img: '/img/user3.jpg' },
-    { id: 2, name: '적대적 노이즈 02', date: '2025. 3. 21. 금요일', img: '/img/user2.jpg' },
-    { id: 1, name: '적대적 노이즈 01', date: '2025. 3. 21. 금요일', img: '/img/user1.jpg' },
-];
+type NoiseRecord = {
+    noiseId: number;
+    originalFilePath: string;
+    createdAt: string;
+}
 
 function NoisePanel() {
-  const navigate = useNavigate();
+    const [records, setRecords] = useState<NoiseRecord[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const navigate = useNavigate();
+    const [showModal, setShowModal] = useState(false);
+    const [deleteId, setDeleteId] = useState<number | null>(null);
+  const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken);  // 로그인 여부만 확인(토큰은 axiosInstance 인터셉터가 알아서 처리)
+
+
+
+  useEffect(() => {
+      if (!isLoggedIn) {
+        setLoading(false);
+        setError("로그인이 필요합니다.");
+        return;
+      }
+        (async () => {
+          try {
+            // 서버는 토큰으로 유저 식별 → userId를 프론트에서 보낼 필요 X
+            const data = await api.noise.getAllByUser(0, 15, "createdAt,desc");
+            // 백엔드 페이지 응답 형태 대비
+            // data가 배열이거나 data.content가 배열일 수 있으니 안전하게 처리
+            const list: any[] = Array.isArray(data)
+              ? data
+              : Array.isArray(data?.content)
+              ? data.content
+              : [];
+  
+            const mapped: NoiseRecord[] = list.map((item: any) => ({
+              noiseId: item.noiseId,
+              originalFilePath: item.originalFilePath ?? item.processedFilePath ?? "",
+              createdAt: item.createdAt ?? "",
+            }));
+            setRecords(mapped);
+          } catch (e) {
+            setError("기록을 불러오지 못했습니다.");
+          } finally {
+            setLoading(false); //  성공/실패 관계없이 로딩 종료
+          }
+        })();
+      }, [isLoggedIn]);
+
+  // 오래된 순으로 정렬 → 번호 붙이기
+  const recordsWithIndex = records
+  .slice()
+  .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) // 오래된 → 최신
+  .map((record, index) => ({
+    ...record,
+    displayIndex: index + 1, // 오래된 순서 기준 번호
+  }));
+
+  //  RecordPage에 맞게 데이터 변환, 다시 최신순으로 정렬해서 화면에 표시
+  const formattedRecords = recordsWithIndex
+  .slice()// 원본 배열 수정 방지
+  .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()) // 최신순: 최신 → 오래된 순
+  .map((record) => ({
+    id: record.noiseId,
+    name: `적대적 노이즈 삽입 결과 ${record.displayIndex}`,
+    date: new Date(record.createdAt).toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      weekday: "long",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }),
+    img: record.originalFilePath,
+  }));
+
+    
     return(
     <RecordPage
         title="적대적 노이즈 기록"
-        records={noiseRecords}
+        records={formattedRecords}
         onAddClick={() => navigate("/adversarial-noise")}
         showDownloadButton={true}
     />
     )
 }
 export default NoisePanel;
+
+

--- a/src/pages/Mypage/Panel/NoisePanel.tsx
+++ b/src/pages/Mypage/Panel/NoisePanel.tsx
@@ -83,14 +83,56 @@ function NoisePanel() {
     img: record.originalFilePath,
   }));
 
+  //기록 삭제
+  const handleDelete = (id: number) => {
+    setDeleteId(id);
+    setShowModal(true);
+  };
+
+  const confirmDelete = () => {
+    if (deleteId === null) return;
+
+    api.noise
+      .deleteById(deleteId)
+      .then(() => {
+        setRecords((prev) => prev.filter((r) => r.noiseId !== deleteId));
+      })
+      .catch(() => {
+        alert("삭제에 실패했습니다.");
+      })
+      .finally(() => {
+        setShowModal(false);
+        setDeleteId(null);
+      });
+    };
+
     
     return(
+    <>
     <RecordPage
         title="적대적 노이즈 기록"
         records={formattedRecords}
         onAddClick={() => navigate("/adversarial-noise")}
-        showDownloadButton={true}
+        onDeleteClick={handleDelete}
+        showDownloadButton={false}
     />
+    {/* 에러/로딩 상태 메시지 (리스트 아래에 보여짐) */}
+      {loading && (
+        <p className="text-center mt-4 text-gray-900">불러오는 중...</p>
+      )}
+      {!loading && error && (
+        <p className="text-center mt-4 text-red-500">{error}</p>
+      )}
+
+      {showModal && (
+        <ConfirmModal
+          message="기록을 삭제할 경우,\n복구가 불가합니다.\n정말 삭제하시겠습니까?"
+          buttonmessage="삭제"
+          onConfirm={confirmDelete}
+          onCancel={() => setShowModal(false)}
+        />
+      )}
+    </>
     )
 }
 export default NoisePanel;

--- a/src/pages/Mypage/Panel/NoisePanelReport.tsx
+++ b/src/pages/Mypage/Panel/NoisePanelReport.tsx
@@ -1,0 +1,42 @@
+import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "../../../app/store";
+import WatermarkReport from "../../../components/Report/WatermarkSuccessReport";
+import { api } from "../../../api";
+
+
+function NoisePanelReport() {
+  
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const [results, setResults] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken);
+  
+  useEffect(() => {
+    if (!id || ! isLoggedIn) return;
+
+    //노이즈 개별 조회
+    api.noise
+      .getById(Number(id))
+      .then((data) => {
+        setResults(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error("조회 실패", err);
+        alert("개별 적대적 노이즈 정보를 불러오는 데 실패했습니다.");
+        navigate("/pages/NotFound");
+      });
+  }, [id,  isLoggedIn, navigate]);
+
+  if (loading) return <p className="text-white-100 text-center mt-10">불러오는 중...</p>;
+  if (!results) return null;
+
+  return (<></>
+    //<WatermarkReport result={results} confirmMessage={null} />
+  )
+}
+export default NoisePanelReport;

--- a/src/pages/Watermark/WatermarkDetection.tsx
+++ b/src/pages/Watermark/WatermarkDetection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import FileUploadPage from "../../components/Upload/FileUploadPage";
 import { useNavigate } from "react-router-dom";
 import { postWatermarkDetection } from "../../api/watermark_api";
@@ -13,6 +13,13 @@ function WatermarkDetection() {
   const navigate = useNavigate();
 
   const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken); 
+
+  useEffect(() => {
+      if (!isLoggedIn) {
+        navigate("/login");
+      }
+    }, [isLoggedIn, navigate]);
+  
 
   const handleDone = async () => {
     if (!isLoggedIn) {

--- a/src/pages/Watermark/WatermarkInsert.tsx
+++ b/src/pages/Watermark/WatermarkInsert.tsx
@@ -1,11 +1,23 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import FileUploadPage from "../../components/Upload/FileUploadPage";
 import InsertFail from "../../components/InsertFail";
 import InsertLoading from "../../components/InsertLoading";
+import { useSelector } from "react-redux";
+import { RootState } from "../../app/store";
+import { useNavigate } from "react-router-dom";
 
 function WatermarkInsert() {
   const [file, setFile] = useState<File | null>(null);
   const [isModal, setIsModal] = useState(false);
+  const navigate = useNavigate();
+  const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken);  // 로그인 여부만 확인(토큰은 axiosInstance 인터셉터가 알아서 처리)
+  console.log("isLoggedIn", isLoggedIn);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      navigate("/login");
+    }
+  }, [isLoggedIn, navigate]);
 
   const handleDone = () => {
     setIsModal(true);


### PR DESCRIPTION
## 📝 Summary
> 적대적 노이즈 기록 전체조회와 삭제 구현했습니다. 
마이페이지 패널 딥페이크로 고정되지 않고 새로고침해도 전에 있던 패널로 바로 연결되도록 수정했습니다.
그 외 자잘한 에러들 수정했습니다.

## 💻 Describe your changes
<img width="1898" height="934" alt="image" src="https://github.com/user-attachments/assets/450289b9-3a73-44d4-a6af-4b0e1fa362d4" />

> api>noise.ts 생성
>->생성 제외한 전체조회, 개별조회, 삭제 api 넣어두었습니다.

>pages>Mypage>Panel>NoisePanel.ts 수정

>pages>Mypage>Mypage.tsx
>->탭 변경 시 URL과 세션스토리지에 동기화

## #️⃣ Issue number and link
> #37 

## 💬 Message to the Reviewer
> 개별 기록 조회는 백엔드쪽에서 수정이 있다고해서 수정 전달 받은 후 만들겠습니다.

