### PR TITLE
ETR-85 Feat: 적대적 노이즈 개별기록 조회 & Design: 적대적노이즈 탐지 UI 수정

### DIFF
--- a/src/api/noise.ts
+++ b/src/api/noise.ts
@@ -2,10 +2,23 @@ import axiosInstance from "./axiosInstance";
 
 export interface NoiseResponse {
     noiseId: number;
+    fileName: string;
     originalFilePath: string;
     processedFilePath: string;
     epsilon: number;
+    attackSuccess: boolean;
+    originalPrediction: string;
+    adversarialPrediction: string;
+    mode: string;
+    level?: number;
+    modeDescription: string;
     createdAt: string;
+    originalImageBase64: string;
+    processedImageBase64: string;
+    originalConfidence: string;
+    adversarialConfidence: string;
+    confidenceDrop: string;
+    styleTransform: string;
 }
 
 export const noiseAPI = {

--- a/src/api/noise.ts
+++ b/src/api/noise.ts
@@ -1,26 +1,5 @@
 import axiosInstance from "./axiosInstance";
 
-export interface NoiseResponse {
-    noiseId: number;
-    fileName: string;
-    originalFilePath: string;
-    processedFilePath: string;
-    epsilon: number;
-    attackSuccess: boolean;
-    originalPrediction: string;
-    adversarialPrediction: string;
-    mode: string;
-    level?: number;
-    modeDescription: string;
-    createdAt: string;
-    originalImageBase64: string;
-    processedImageBase64: string;
-    originalConfidence: string;
-    adversarialConfidence: string;
-    confidenceDrop: string;
-    styleTransform: string;
-}
-
 export const noiseAPI = {
     getAllByUser: async (page = 0, size = 15, sort = "createdAt,desc") => {
       const res = await axiosInstance.get("/api/noise/history", {

--- a/src/components/Report/DeepfakeReport.tsx
+++ b/src/components/Report/DeepfakeReport.tsx
@@ -1,6 +1,6 @@
 import { PieChart, Pie, Cell, Label } from "recharts";
 import ReportNotice from "./ReportNotice";
-import { IoClose } from "react-icons/io5";
+import { IoArrowBack } from "react-icons/io5";
 import { useNavigate } from "react-router-dom";
 
 const COLORS = ["#3D3D42", "#FFFFFF"]; // gray, white
@@ -21,7 +21,7 @@ interface Props {
     sampleCount?: number
   };
   createdAt?: string; // 2. 바깥에서 별도로 받는 createdAt
-  showDownloadButton?: boolean;
+  showXButton?: boolean;
 }
 
 function shrinkValue(x: number): number {
@@ -29,7 +29,7 @@ function shrinkValue(x: number): number {
   return Math.pow(x, alpha)*100;
 }
 
-function DeepfakeReport({ result, createdAt, showDownloadButton = true }: Props) {
+function DeepfakeReport({ result, createdAt, showXButton = true }: Props) {
   const averageFakeinit = result?.averageConfidence ?? 0;
   const maxConfidenceinit = result?.maxConfidence ?? 0;
   const suspectImage = result?.filePath ?? null;
@@ -65,16 +65,16 @@ function DeepfakeReport({ result, createdAt, showDownloadButton = true }: Props)
 
 
   return (
-    <div className="relative min-h-screen px-20 py-10 mx-20">
-      {showDownloadButton && (
+    <div className="relative min-h-screen px-20 py-10">
+      {showXButton && (
         <button 
-        onClick={handleClose}
-        className="absolute top-4 right-1 text-white-100 hover:text-gray-50">
-          <IoClose size={30} />
-      </button>
+          onClick={handleClose}
+          className="absolute top-10 left-3 text-white-100 hover:text-gray-50">
+            <IoArrowBack size={60} />
+        </button>
       )}
       {/* 헤더 */}
-      <div className="bg-white-200 p-6 rounded-xl mb-6">
+      <div className="bg-white-200 p-6 rounded-xl mb-6 mx-20">
         <h2 className="text-3xl font-semibold mb-3">딥페이크 탐지</h2>
         <p className="text-sm">
           분석 날짜: {createdAt ? new Date(createdAt).toLocaleString("ko-KR") : new Date().toLocaleString("ko-KR")} | 영상 분석
@@ -125,7 +125,7 @@ function DeepfakeReport({ result, createdAt, showDownloadButton = true }: Props)
       </div>
 
       {/* 그래프+결과 */}
-      <div className="bg-white-200 text-black-100 p-6 rounded-xl mb-6 flex gap-6  justify-center items-center">
+      <div className="bg-white-200 text-black-100 p-6 rounded-xl mb-6 mx-20 flex gap-6  justify-center items-center">
         {/*파이차트 */}
         <div className="relative w-[300px] h-[300px] mr-20 flex items-center justify-center">
           <PieChart width={300} height={300}>
@@ -184,7 +184,7 @@ function DeepfakeReport({ result, createdAt, showDownloadButton = true }: Props)
       </div>
 
       {/* 탐지된 영역 */}
-      <div className="bg-gray-100 text-black p-6 rounded-xl mb-6">
+      <div className="bg-gray-100 text-black p-6 rounded-xl mb-6 mx-20">
         <h3 className="text-2xl font-bold mb-4">✔️ 가장 높게 탐지된 영역</h3>
         <div className="flex items-center justify-center">
           {suspectImage ? (
@@ -210,7 +210,9 @@ function DeepfakeReport({ result, createdAt, showDownloadButton = true }: Props)
 
       {/* 주의 사항 */}
       {fake > 50 && (
-        <ReportNotice />
+        <div className="mx-20">
+          <ReportNotice />
+        </div>
       )}
     </div>
   );

--- a/src/components/Report/DeepfakeReport.tsx
+++ b/src/components/Report/DeepfakeReport.tsx
@@ -63,10 +63,6 @@ function DeepfakeReport({ result, createdAt, showDownloadButton = true }: Props)
     navigate(-1); // 이전 페이지로 이동
   }
 
-  let modemessage = "";
-  if (mode === 'DEFAULT') modemessage="기본모드";
-  else modemessage = "정밀모드"
-
 
   return (
     <div className="relative min-h-screen px-20 py-10 mx-20">
@@ -85,7 +81,7 @@ function DeepfakeReport({ result, createdAt, showDownloadButton = true }: Props)
         </p>
         <div className="w-full my-[1%] border-t border-black-100"></div>
         <p className="text-base mb-1">
-          {modemessage}
+          {(mode === 'DEFAULT') ? "기본모드" : "정밀모드"}
         </p>
         <div className="flex w-full">
           <label className="inline-flex items-center gap-1 cursor-pointer">

--- a/src/components/Report/NoiseReport.tsx
+++ b/src/components/Report/NoiseReport.tsx
@@ -1,3 +1,4 @@
+import { IoArrowBack } from "react-icons/io5";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
 type Props={
@@ -21,9 +22,10 @@ type Props={
     styleTransform: string;
   };
   confirmMessage?: string | null;
+  showXButton?: boolean;
 }
 
-function NoiseReport({ data, confirmMessage }: Props) {
+function NoiseReport({ data, confirmMessage, showXButton = true }: Props) {
 
   const navigate = useNavigate();
 
@@ -52,6 +54,13 @@ function NoiseReport({ data, confirmMessage }: Props) {
 
   return(
     <div className="w-full flex flex-col items-center justify-center gap-3">
+      {showXButton && (
+        <button 
+          onClick={handleClose}
+          className="absolute top-[11%] left-5 text-white-100 hover:text-gray-50">
+          <IoArrowBack size={60} />
+        </button>
+      )}
       {/* 이미지 비교 */}
       <div className="w-[1200px] flex justify-center gap-[50px] my-5">
 
@@ -87,20 +96,20 @@ function NoiseReport({ data, confirmMessage }: Props) {
         <div className="flex justify-center w-[100%] gap-5 text-center">
           <div className="w-[10%] bg-white-100 rounded-[10px] p-5">
             <p>결과</p>
-            <p className="font-bold text-[20px] mt-2">{data.attackSuccess ? '공격 성공' : '공격 실패'}</p>
+            <p className="font-bold text-[20px] mt-5">{data.attackSuccess ? '공격 성공' : '공격 실패'}</p>
           </div>
           <div className="w-[20%] bg-white-100 rounded-[10px] p-5">
             <p>분류 변화</p>
             <p className="font-bold text-[20px] mt-2">{data.originalPrediction}</p>
-            <p className="font-bold text-[20px] ">→{data.adversarialPrediction}</p>
+            <p className="font-bold text-[20px]">→{data.adversarialPrediction}</p>
           </div>
           <div className="w-[10%] bg-white-100 rounded-[10px] p-5">
             <p>신뢰도 변화</p>
-            <p className="font-bold text-[20px] mt-2">{data.confidenceDrop || '0%'}</p>
+            <p className="font-bold text-[20px] mt-5">{data.confidenceDrop || '0%'}</p>
           </div>
           <div className="w-[15%] bg-white-100 rounded-[10px] p-5">
             <p>적대적 노이즈 강도</p>
-            <p className="font-bold text-[20px] mt-2">{data.modeDescription}</p>
+            <p className="font-bold text-[20px] mt-5">{data.modeDescription}</p>
             {(data.mode === 'precision') && <p className="font-bold text-[20px] ">{data.level}</p>}
           </div>
         </div>

--- a/src/components/Report/NoiseReport.tsx
+++ b/src/components/Report/NoiseReport.tsx
@@ -1,5 +1,6 @@
+import { ReactElement } from "react";
 import { IoArrowBack } from "react-icons/io5";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 type Props={
   data: {
@@ -21,7 +22,7 @@ type Props={
     confidenceDrop: string;
     styleTransform: string;
   };
-  confirmMessage?: string | null;
+  confirmMessage?: ReactElement | null;
   showXButton?: boolean;
 }
 
@@ -38,7 +39,7 @@ function NoiseReport({ data, confirmMessage, showXButton = true }: Props) {
       const blob = await response.blob();
       const link = document.createElement("a");
       link.href = window.URL.createObjectURL(blob);;
-      link.download = ``;
+      link.download = data.fileName;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -123,7 +124,7 @@ function NoiseReport({ data, confirmMessage, showXButton = true }: Props) {
           onClick={handleDownload}>
           노이즈 삽입 이미지 다운로드
         </button>
-        <p>{confirmMessage}</p>
+        {confirmMessage}
       </div>
     </div>
   );

--- a/src/components/Report/NoiseReport.tsx
+++ b/src/components/Report/NoiseReport.tsx
@@ -1,0 +1,123 @@
+import { Link, useLocation, useNavigate } from "react-router-dom";
+
+type Props={
+  data: {
+    fileName: string;
+    originalFilePath: string;
+    processedFilePath: string;
+    epsilon: number;
+    attackSuccess: boolean;
+    originalPrediction: string;
+    adversarialPrediction: string;
+    mode: string;
+    level?: number;
+    modeDescription: string;
+    createdAt: string;
+    originalImageBase64: string;
+    processedImageBase64: string;
+    originalConfidence: string;
+    adversarialConfidence: string;
+    confidenceDrop: string;
+    styleTransform: string;
+  };
+  confirmMessage?: string | null;
+}
+
+function NoiseReport({ data, confirmMessage }: Props) {
+
+  const navigate = useNavigate();
+
+  const originalImage = data.originalImageBase64;
+  const NoisedImage = data.processedImageBase64;
+
+  const handleDownload = async () => {
+    try {
+      const response = await fetch(NoisedImage, { mode: "cors" });
+      const blob = await response.blob();
+      const link = document.createElement("a");
+      link.href = window.URL.createObjectURL(blob);;
+      link.download = ``;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(link.href);
+    } catch (error) {
+      console.log("다운로드 실패:", error);
+      alert("다운로드에 실패했습니다.");
+    }
+  }
+  const handleClose = () => {
+    navigate(-1); // 이전 페이지로 이동
+  }
+
+  return(
+    <div className="w-full flex flex-col items-center justify-center gap-3">
+      {/* 이미지 비교 */}
+      <div className="w-[1200px] flex justify-center gap-[50px] my-5">
+
+        <div className="bg-gray-300 w-[50%] flex flex-col items-center justify-center rounded-[10px] gap-3 py-3">
+          <h3 className="font-bold">🖼️ 원본 이미지</h3>
+          <img
+            src={data.originalFilePath}
+            alt="원본 이미지" />
+          <div className="bg-white-100 w-[80%] flex flex-col justify-center items-center rounded-[10px]">
+            <p>AI 예측</p>
+            <p className="font-bold">{data.originalPrediction}</p>
+            <p>신뢰도: {data.originalConfidence}</p>
+          </div>
+          
+        </div>
+
+        <div className="bg-gray-300 w-[50%] flex flex-col items-center justify-center rounded-[10px] gap-3">
+          <h3 className="font-bold">⚡ 적대적 노이즈 적용</h3>
+          <img
+            src={data.processedFilePath}
+            alt="노이즈 삽입 완료 이미지" />
+          <div className="bg-white-100 w-[80%] flex flex-col justify-center items-center rounded-[10px]">
+            <p>AI 예측</p>
+            <p className="font-bold">{data.adversarialPrediction}</p>
+            <p>신뢰도: {data.adversarialConfidence}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* 통계 정보 */}
+      <div className="w-[1200px] flex flex-col items-center justify-center mt-5 p-5 gap-5 rounded-[10px] bg-blue-100">
+        <h1 className="font-bold text-2xl">📊 상세 통계</h1>
+        <div className="flex justify-center w-[100%] gap-5 text-center">
+          <div className="w-[10%] bg-white-100 rounded-[10px] p-5">
+            <p>결과</p>
+            <p className="font-bold text-[20px] mt-2">{data.attackSuccess ? '공격 성공' : '공격 실패'}</p>
+          </div>
+          <div className="w-[20%] bg-white-100 rounded-[10px] p-5">
+            <p>분류 변화</p>
+            <p className="font-bold text-[20px] mt-2">{data.originalPrediction}</p>
+            <p className="font-bold text-[20px] ">→{data.adversarialPrediction}</p>
+          </div>
+          <div className="w-[10%] bg-white-100 rounded-[10px] p-5">
+            <p>신뢰도 변화</p>
+            <p className="font-bold text-[20px] mt-2">{data.confidenceDrop || '0%'}</p>
+          </div>
+          <div className="w-[15%] bg-white-100 rounded-[10px] p-5">
+            <p>적대적 노이즈 강도</p>
+            <p className="font-bold text-[20px] mt-2">{data.modeDescription}</p>
+            {(data.mode === 'precision') && <p className="font-bold text-[20px] ">{data.level}</p>}
+          </div>
+        </div>
+      </div>
+
+      {/* 버튼 */}
+      <div className="text-white-100 flex flex-col justify-center items-center gap-5">
+        <h1 className="font-bold text-[40px]">적대적 노이즈 삽입이 완료되었습니다!</h1>
+        <button 
+          className="w-[355px] h-[57px] rounded-[50px] bg-green-200 text-[20px]"
+          onClick={handleDownload}>
+          노이즈 삽입 이미지 다운로드
+        </button>
+        <p>{confirmMessage}</p>
+      </div>
+    </div>
+  );
+}
+
+export default NoiseReport;

--- a/src/components/Report/WatermarkSuccessReport.tsx
+++ b/src/components/Report/WatermarkSuccessReport.tsx
@@ -1,4 +1,4 @@
-import { IoClose } from "react-icons/io5";
+import { IoArrowBack } from "react-icons/io5";
 import { useNavigate } from "react-router-dom";
 
 type Props={
@@ -46,8 +46,8 @@ function WatermarkSuccessReport({ result, confirmMessage }: Props) {
     <div className="relative w-full h-full flex flex-col justify-center items-center gap-7 text-white-100">
       <button 
         onClick={handleClose}
-        className="absolute top-4 right-4 text-white-100 hover:text-gray-50">
-          <IoClose size={30} />
+        className="absolute top-4 left-5 text-white-100 hover:text-gray-50">
+          <IoArrowBack size={60} />
       </button>
       {image ? (
         <div className="flex mt-8">

--- a/src/components/Upload/AdversarialNoise/NoiseOptionPanel.tsx
+++ b/src/components/Upload/AdversarialNoise/NoiseOptionPanel.tsx
@@ -14,7 +14,7 @@ function NoiseOptionPanel({ value, onChange }: OptionsPanelProps) {
     onChange({ ...value, [k]: v });
 
   const Select = ({ label, value, options, onChange }:{
-    label: string; value: string; options: {value:string; label:string}[]; onChange:(v:string)=>void; 
+    label: string; value: number; options: {value:number; label:string}[]; onChange:(v:number)=>void; 
   }) => {
       const [openSel, setOpenSel] = useState(false);
       return (
@@ -74,10 +74,10 @@ function NoiseOptionPanel({ value, onChange }: OptionsPanelProps) {
               label="강도 단계"
               value={value.level}
               options={[
-                { value: '1', label: '1' },
-                { value: '2', label: '2' },
-                { value: '3', label: '3' },
-                { value: '4', label: '4' },
+                { value: 1, label: '1' },
+                { value: 2, label: '2' },
+                { value: 3, label: '3' },
+                { value: 4, label: '4' },
               ]}
               onChange={(v) => set('level', v as NoiseOptions['level'])}
             />

--- a/src/components/Upload/AdversarialNoise/NoiseOptionPanel.tsx
+++ b/src/components/Upload/AdversarialNoise/NoiseOptionPanel.tsx
@@ -1,0 +1,89 @@
+import { useId, useState } from 'react';
+import { NoiseOptions } from '../deepfake/ModeOptions';
+
+interface OptionsPanelProps {
+  value: NoiseOptions;
+  onChange: (next: NoiseOptions) => void;
+}
+
+function NoiseOptionPanel({ value, onChange }: OptionsPanelProps) {
+  const [open, setOpen] = useState(false);
+  const secId = useId();
+
+  const set = <K extends keyof NoiseOptions>(k: K, v: NoiseOptions[K]) =>
+    onChange({ ...value, [k]: v });
+
+  const Select = ({ label, value, options, onChange }:{
+    label: string; value: string; options: {value:string; label:string}[]; onChange:(v:string)=>void; 
+  }) => {
+      const [openSel, setOpenSel] = useState(false);
+      return (
+        <div className="py-2">
+          <div className="flex items-center justify-between text-lg">
+              <span>{label}</span>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 px-2 py-1 border rounded-md text-lg"
+                onClick={() => setOpenSel((s) => !s)}>
+                <span className="font-medium">{value}</span>
+                <svg width="12" height="12" viewBox="0 0 20 20" className={`transition ${openSel ? 'rotate-180' : ''}`}>
+                  <path d="M5 7l5 6 5-6" fill="none" stroke="currentColor" strokeWidth="2" />
+                </svg>
+              </button>
+            </div>
+            {openSel && (
+              <ul className="mt-2 border rounded-md bg-white shadow-sm divide-y" role="listbox" aria-labelledby={secId + '-select'}>
+                {options.map((opt) => (
+                  <li key={opt.value}>
+                    <button
+                      type="button"
+                      className={`w-full text-left px-3 py-2 text-base hover:bg-emerald-50 ${value === opt.value ? 'text-green-200 font-base' : ''}`}
+                      role="option"
+                      aria-selected={value === opt.value}
+                      onClick={() => { onChange(opt.value); setOpenSel(false); }}>
+                      {opt.label}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        );
+      };
+
+    return (
+      <section className="rounded-xl border bg-white-100 p-4">
+        {/* 아코디언 헤더 */}
+        <button
+          type="button"
+          className="w-full flex items-center justify-between"
+          aria-expanded={open}
+          aria-controls={secId}
+          onClick={() => setOpen((s) => !s)}>
+            <span className="text-xl font-medium mr-1">상세옵션</span>
+            <svg width="20" height="20" viewBox="0 0 20 20" className={`transition ${open ? 'rotate-180' : ''}`}>
+              <path d="M5 7l5 6 5-6" fill="none" stroke="currentColor" strokeWidth="2" />
+            </svg>
+        </button>
+
+        {/* 본문 */}
+        {open && (
+          <div id={secId} className="mt-3 space-y-2 border-t">
+            {/* 드롭다운 */}
+            <Select
+              label="강도 단계"
+              value={value.level}
+              options={[
+                { value: '1', label: '1' },
+                { value: '2', label: '2' },
+                { value: '3', label: '3' },
+                { value: '4', label: '4' },
+              ]}
+              onChange={(v) => set('level', v as NoiseOptions['level'])}
+            />
+          </div>
+        )}
+      </section>
+    );
+  }
+export default NoiseOptionPanel;

--- a/src/components/Upload/AdversarialNoise/NoiseSetting.tsx
+++ b/src/components/Upload/AdversarialNoise/NoiseSetting.tsx
@@ -4,7 +4,7 @@ import NoiseOptionPanel from './NoiseOptionPanel';
 import { Mode, NoiseOptions } from '../deepfake/ModeOptions'
 
 const defaultOptions: NoiseOptions = { //정밀모드 기본세팅
-  level: '2',
+  level: 2,
 };
 
 interface NoiseSettingProps {

--- a/src/components/Upload/AdversarialNoise/NoiseSetting.tsx
+++ b/src/components/Upload/AdversarialNoise/NoiseSetting.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import ModeSelector from '../deepfake/ModeSelector';
+import NoiseOptionPanel from './NoiseOptionPanel';
+import { Mode, NoiseOptions } from '../deepfake/ModeOptions'
+
+const defaultOptions: NoiseOptions = { //정밀모드 기본세팅
+  level: '2',
+};
+
+interface NoiseSettingProps {
+  onChange?: (mode: Mode, options: NoiseOptions) => void; // 부모(페이지)로 값 전달
+}
+
+function NoiseSetting({ onChange }: NoiseSettingProps) {
+  const [mode, setMode] = useState<Mode>('basic');
+  const [opts, setOpts] = useState<NoiseOptions>(defaultOptions);
+
+  useEffect(() => {
+    onChange?.(mode, opts);
+  }, [mode, opts, onChange]);
+
+  return (
+    <div className="border-b p-2">
+      {/* 모드 선택 */}
+      <div className="mb-4">
+        <ModeSelector value={mode} onChange={setMode} basicname='자동모드'/>
+      </div>
+
+      {/* 정밀모드일 때만 옵션 보이기 */}
+      {mode === 'advanced' && (
+        <NoiseOptionPanel value={opts} onChange={setOpts} />
+      )}
+    </div>
+  );
+}
+export default NoiseSetting;

--- a/src/components/Upload/deepfake/DeepfakeSetting.tsx
+++ b/src/components/Upload/deepfake/DeepfakeSetting.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import ModeSelector from './ModeSelector';
-import OptionsPanel from './OptionPanel';
-import { DetectionOptions, Mode } from './DetectionOptions';
+import OptionPanel from './OptionPanel';
+import { DetectionOptions, Mode } from './ModeOptions';
 
 const defaultOptions: DetectionOptions = { //정밀모드 기존 기본세팅
   use_tta: true,
@@ -12,11 +12,11 @@ const defaultOptions: DetectionOptions = { //정밀모드 기존 기본세팅
   detector: 'Auto',
 };
 
-interface DeepfakeSettingsProps {
+interface DeepfakeSettingProps {
   onChange?: (mode: Mode, options: DetectionOptions) => void; // 부모(페이지)로 값 전달
 }
 
-function DeepfakeSettings({ onChange }: DeepfakeSettingsProps) {
+function DeepfakeSetting({ onChange }: DeepfakeSettingProps) {
   const [mode, setMode] = useState<Mode>('basic');
   const [opts, setOpts] = useState<DetectionOptions>(defaultOptions);
 
@@ -28,14 +28,14 @@ function DeepfakeSettings({ onChange }: DeepfakeSettingsProps) {
     <div className="border-b p-2">
       {/* 모드 선택 */}
       <div className="mb-4">
-        <ModeSelector value={mode} onChange={setMode} />
+        <ModeSelector value={mode} onChange={setMode} basicname='기본모드'/>
       </div>
 
       {/* 정밀모드일 때만 옵션 보이기 */}
       {mode === 'advanced' && (
-        <OptionsPanel value={opts} onChange={setOpts} />
+        <OptionPanel value={opts} onChange={setOpts} />
       )}
     </div>
   );
 }
-export default DeepfakeSettings;
+export default DeepfakeSetting;

--- a/src/components/Upload/deepfake/ModeOptions.ts
+++ b/src/components/Upload/deepfake/ModeOptions.ts
@@ -10,5 +10,5 @@ export interface DetectionOptions {
 }
 
 export interface NoiseOptions {
-  level : '1' | '2' | '3' | '4' ;
+  level : 1 | 2 | 3 | 4 ;
 }

--- a/src/components/Upload/deepfake/ModeOptions.ts
+++ b/src/components/Upload/deepfake/ModeOptions.ts
@@ -8,3 +8,7 @@ export interface DetectionOptions {
   sample_count: number;             // 슬라이더3 (샘플 이미지 수)
   detector: 'Auto' | 'Dlib' | 'Dnn' ; // 드롭다운
 }
+
+export interface NoiseOptions {
+  level : '1' | '2' | '3' | '4' ;
+}

--- a/src/components/Upload/deepfake/ModeSelector.tsx
+++ b/src/components/Upload/deepfake/ModeSelector.tsx
@@ -1,11 +1,12 @@
-import { Mode } from './DetectionOptions';
+import { Mode } from './ModeOptions';
 
 interface ModeSelectorProps {
   value: Mode;
   onChange: (m: Mode) => void;
+  basicname: string;
 }
 
-function ModeSelector({ value, onChange }: ModeSelectorProps) {
+function ModeSelector({ value, onChange, basicname }: ModeSelectorProps) {
   return (
     <div className="flex items-center justify-center gap-6">
       <label className="inline-flex items-center gap-2 cursor-pointer">
@@ -22,7 +23,7 @@ function ModeSelector({ value, onChange }: ModeSelectorProps) {
           }`}
           aria-hidden
         />
-        <span className="text-3xl font-semibold">기본모드</span>
+        <span className="text-3xl font-semibold">{basicname}</span>
         {value === 'basic' ? (
           <span className="ml-1 mr-20 text-[10px] px-1.5 py-0.5 rounded bg-emerald-100 text-green-200">ON</span>
         ) : (

--- a/src/components/Upload/deepfake/OptionPanel.tsx
+++ b/src/components/Upload/deepfake/OptionPanel.tsx
@@ -1,5 +1,5 @@
 import { useId, useState } from 'react';
-import { DetectionOptions } from './DetectionOptions';
+import { DetectionOptions } from './ModeOptions';
 import RadixSlider from './RadixSlider';
 import TooltipInfo from '../../Modal/TooltipInfo';
 

--- a/src/pages/AdversarialNoise/AdversarialNoise.tsx
+++ b/src/pages/AdversarialNoise/AdversarialNoise.tsx
@@ -14,7 +14,7 @@ function AdversarialNoise() {
   const navigate = useNavigate();
   const [mode, setMode] = useState<Mode>("basic");
   const [options, setOptions] = useState<NoiseOptions>({
-    level: '2',
+    level: 2,
   });
 
   const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken);

--- a/src/pages/AdversarialNoise/AdversarialNoise.tsx
+++ b/src/pages/AdversarialNoise/AdversarialNoise.tsx
@@ -4,11 +4,18 @@ import { postNoiseImage } from "../../api/noise_api";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
+import DeepfakeFileUpload from "../../components/Upload/deepfake/DeepfakeFileUpload";
+import NoiseSetting from "../../components/Upload/AdversarialNoise/NoiseSetting";
+import { Mode, NoiseOptions } from "../../components/Upload/deepfake/ModeOptions"
 
 function AdversarialNoise() {
 
   const [file, setFile] = useState<File | null>(null);
   const navigate = useNavigate();
+  const [mode, setMode] = useState<Mode>("basic");
+  const [options, setOptions] = useState<NoiseOptions>({
+    level: '2',
+  });
 
   const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken);
 
@@ -37,12 +44,22 @@ function AdversarialNoise() {
 
   return(
     <>
+      {/* 
       <FileUploadPage 
         title="이미지"
         file={file}
         setFile={setFile}
         accpet="image/*"
         onDone={handleNoiseInsert}
+      />*/}
+      <DeepfakeFileUpload
+        title="이미지"
+        file={file}
+        setFile={setFile}
+        accpet="image/*"
+        onDone={handleNoiseInsert}
+        settingsNode={<NoiseSetting onChange={(m, o) => { setMode(m); setOptions(o); }} />}
+    
       />
     </>)
 }

--- a/src/pages/AdversarialNoise/NoiseResult.tsx
+++ b/src/pages/AdversarialNoise/NoiseResult.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
+import NoiseReport from "../../components/Report/NoiseReport";
 
 function NoiseResult() {
 
@@ -6,93 +7,13 @@ function NoiseResult() {
   const data = location.state?.data;
   console.log(data);
 
-  const originalImage = data.originalImageBase64;
-  const NoisedImage = data.processedImageBase64;
-
-  const handleDownload = async () => {
-    try {
-      const response = await fetch(originalImage, { mode: "cors" });
-      const blob = await response.blob();
-      const link = document.createElement("a");
-      link.href = window.URL.createObjectURL(blob);;
-      link.download = ``;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(link.href);
-    } catch (error) {
-      console.log("다운로드 실패:", error);
-      alert("다운로드에 실패했습니다.");
-    }
-  }
 
   return(
-    <div className="w-full flex flex-col items-center justify-center gap-3">
-      {/* 이미지 비교 */}
-      <div className="w-[1200px] flex justify-center gap-[50px] my-5">
-
-        <div className="bg-gray-300 w-[50%] flex flex-col items-center justify-center rounded-[10px] gap-3 py-3">
-          <h3 className="font-bold">🖼️ 원본 이미지</h3>
-          <img
-            src={originalImage}
-            alt="원본 이미지" />
-          <div className="bg-white-100 w-[80%] flex flex-col justify-center items-center rounded-[10px]">
-            <p>AI 예측</p>
-            <p className="font-bold">{data.originalPrediction}</p>
-            <p>신뢰도: {data.originalConfidence}</p>
-          </div>
-          
-        </div>
-
-        <div className="bg-gray-300 w-[50%] flex flex-col items-center justify-center rounded-[10px] gap-3">
-          <h3 className="font-bold">⚡ 노이즈 적용</h3>
-          <img
-            src={NoisedImage}
-            alt="노이즈 삽입 완료 이미지" />
-          <div className="bg-white-100 w-[80%] flex flex-col justify-center items-center rounded-[10px]">
-            <p>AI 예측</p>
-            <p className="font-bold">{data.adversarialPrediction}</p>
-            <p>신뢰도: {data.adversarialConfidence}</p>
-          </div>
-        </div>
-      </div>
-
-      {/* 통계 정보 */}
-      <div className="w-[1200px] flex flex-col items-center justify-center mt-5 p-5 gap-5 rounded-[10px] bg-blue-100">
-        <h1 className="font-bold">📊 상세 통계</h1>
-        <div className="flex justify-center w-[100%] gap-5">
-          <div className="w-[10%] bg-white-100 rounded-[10px] p-5 ">
-            <p>신뢰도 감소</p>
-            <p className="font-bold text-[20px] ">{data.confidenceDrop || '0%'}</p>
-          </div>
-          <div className="w-[10%] bg-white-100 rounded-[10px] p-5">
-            <p>엡실론</p>
-            <p className="font-bold text-[20px] ">{data.epsilon}</p>
-          </div>
-          <div className="w-[10%] bg-white-100 rounded-[10px] p-5">
-            <p>공격 결과</p>
-            <p className="font-bold text-[20px] ">{data.attackSuccess ? '공격 성공' : '공격 실패'}</p>
-          </div>
-          <div className="w-[10%] bg-white-100 rounded-[10px] p-5">
-            <p>공격 성공률</p>
-            <p className="font-bold text-[20px] ">{data.attackSuccess ? '100%' : '0%'}</p>
-          </div>
-        </div>
-      </div>
-
-      {/* 버튼 */}
-      <div className="text-white-100 flex flex-col justify-center items-center gap-5">
-        <h1 className="font-bold text-[40px]">적대적 노이즈 삽입이 완료되었습니다!</h1>
-        <button 
-          className="w-[355px] h-[57px] rounded-[50px] bg-green-200 text-[20px]"
-          onClick={handleDownload}>
-          노이즈 삽입 이미지 다운로드
-        </button>
-        <p>
-          <Link to="/mypage">마이페이지</Link>
-          에서도 확인 가능합니다.</p>
-      </div>
-    </div>
+    <NoiseReport 
+      data={data} 
+      confirmMessage={<p><Link to="/mypage">마이페이지</Link>에서도 확인 가능합니다.</p>} 
+      showXButton={false} 
+    />
   );
 }
 

--- a/src/pages/Deepfake/Detection.tsx
+++ b/src/pages/Deepfake/Detection.tsx
@@ -4,8 +4,8 @@ import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
 import { DeepfakeResponse } from "../../api/deepfake";
 import { api } from "../../api";
-import DeepfakeSettings from "../../components/Upload/deepfake/DeepfakeSetting";
-import { Mode, DetectionOptions } from '../../components/Upload/deepfake/DetectionOptions'
+import DeepfakeSetting from "../../components/Upload/deepfake/DeepfakeSetting";
+import { Mode, DetectionOptions } from '../../components/Upload/deepfake/ModeOptions'
 import DeepfakeFileUpload from "../../components/Upload/deepfake/DeepfakeFileUpload";
 
 
@@ -17,11 +17,11 @@ function Detection() {
   const navigate = useNavigate();
   const [mode, setMode] = useState<Mode>("basic");
   const [options, setOptions] = useState<DetectionOptions>({
-    use_tta: false,
-    use_illum: false,
-    smooth_window: 60,
-    min_face: 80,
-    sample_count: 60,
+    use_tta: true,
+    use_illum: true,
+    smooth_window: 5,
+    min_face: 64,
+    sample_count: 15,
     detector: 'Auto',
   });
  
@@ -93,7 +93,7 @@ function Detection() {
         setFile={setFile}
         accpet="video/*"
         onDone={handleDetectionInsert}
-        settingsNode={<DeepfakeSettings onChange={(m, o) => { setMode(m); setOptions(o); }} />}
+        settingsNode={<DeepfakeSetting onChange={(m, o) => { setMode(m); setOptions(o); }} />}
     
       />
     </div> 

--- a/src/pages/Deepfake/DetectionReport.tsx
+++ b/src/pages/Deepfake/DetectionReport.tsx
@@ -22,6 +22,6 @@ function DetectionReport() {
   if (!results) return null;
   console.log("result: " ,results);
   
-  return <DeepfakeReport result={results} showDownloadButton={false}/>;
+  return <DeepfakeReport result={results} showXButton={false}/>;
 }
 export default DetectionReport;

--- a/src/pages/Mypage/Panel/DeepfakePanelReport.tsx
+++ b/src/pages/Mypage/Panel/DeepfakePanelReport.tsx
@@ -36,7 +36,7 @@ function DeepfakePanelReport() {
   if (!results) return null;
 
   return (
-    <DeepfakeReport result={results} createdAt={results.createdAt} showDownloadButton={true}/>
+    <DeepfakeReport result={results} createdAt={results.createdAt} showXButton={true}/>
   )
 }
 export default DeepfakePanelReport;

--- a/src/pages/Mypage/Panel/NoisePanel.tsx
+++ b/src/pages/Mypage/Panel/NoisePanel.tsx
@@ -7,53 +7,51 @@ import { RootState } from "../../../app/store";
 import { api } from "../../../api";
 
 type NoiseRecord = {
-    noiseId: number;
-    originalFilePath: string;
-    createdAt: string;
+  noiseId: number;
+  originalFilePath: string;
+  createdAt: string;
 }
 
 function NoisePanel() {
-    const [records, setRecords] = useState<NoiseRecord[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState("");
-    const navigate = useNavigate();
-    const [showModal, setShowModal] = useState(false);
-    const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [records, setRecords] = useState<NoiseRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+  const [showModal, setShowModal] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
   const isLoggedIn = useSelector((state: RootState) => !!state.auth.accessToken);  // 로그인 여부만 확인(토큰은 axiosInstance 인터셉터가 알아서 처리)
 
-
-
   useEffect(() => {
-      if (!isLoggedIn) {
-        setLoading(false);
-        setError("로그인이 필요합니다.");
-        return;
-      }
-        (async () => {
-          try {
-            // 서버는 토큰으로 유저 식별 → userId를 프론트에서 보낼 필요 X
-            const data = await api.noise.getAllByUser(0, 15, "createdAt,desc");
-            // 백엔드 페이지 응답 형태 대비
-            // data가 배열이거나 data.content가 배열일 수 있으니 안전하게 처리
-            const list: any[] = Array.isArray(data)
-              ? data
-              : Array.isArray(data?.content)
-              ? data.content
-              : [];
+    if (!isLoggedIn) {
+      setLoading(false);
+      setError("로그인이 필요합니다.");
+      return;
+    }
+      (async () => {
+        try {
+          // 서버는 토큰으로 유저 식별 → userId를 프론트에서 보낼 필요 X
+          const data = await api.noise.getAllByUser(0, 15, "createdAt,desc");
+          // 백엔드 페이지 응답 형태 대비
+          // data가 배열이거나 data.content가 배열일 수 있으니 안전하게 처리
+          const list: any[] = Array.isArray(data)
+            ? data
+            : Array.isArray(data?.content)
+            ? data.content
+            : [];
   
-            const mapped: NoiseRecord[] = list.map((item: any) => ({
-              noiseId: item.noiseId,
-              originalFilePath: item.originalFilePath ?? item.processedFilePath ?? "",
-              createdAt: item.createdAt ?? "",
-            }));
-            setRecords(mapped);
-          } catch (e) {
-            setError("기록을 불러오지 못했습니다.");
-          } finally {
-            setLoading(false); //  성공/실패 관계없이 로딩 종료
-          }
-        })();
-      }, [isLoggedIn]);
+          const mapped: NoiseRecord[] = list.map((item: any) => ({
+            noiseId: item.noiseId,
+            originalFilePath: item.originalFilePath ?? item.processedFilePath ?? "",
+            createdAt: item.createdAt ?? "",
+          }));
+          setRecords(mapped);
+        } catch (e) {
+          setError("기록을 불러오지 못했습니다.");
+        } finally {
+          setLoading(false); //  성공/실패 관계없이 로딩 종료
+        }
+      })();
+    }, [isLoggedIn]);
 
   // 오래된 순으로 정렬 → 번호 붙이기
   const recordsWithIndex = records
@@ -113,6 +111,7 @@ function NoisePanel() {
         title="적대적 노이즈 기록"
         records={formattedRecords}
         onAddClick={() => navigate("/adversarial-noise")}
+        onItemClick={(id) => navigate(`/mypage/noise/${id}`)}
         onDeleteClick={handleDelete}
         showDownloadButton={false}
     />

--- a/src/pages/Mypage/Panel/NoisePanelReport.tsx
+++ b/src/pages/Mypage/Panel/NoisePanelReport.tsx
@@ -36,7 +36,7 @@ function NoisePanelReport() {
   if (!results) return null;
 
   return (
-    <NoiseReport data={results} confirmMessage={null} />
+    <NoiseReport data={results} confirmMessage={null} showXButton={true} />
   )
 }
 export default NoisePanelReport;

--- a/src/pages/Mypage/Panel/NoisePanelReport.tsx
+++ b/src/pages/Mypage/Panel/NoisePanelReport.tsx
@@ -2,8 +2,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { RootState } from "../../../app/store";
-import WatermarkReport from "../../../components/Report/WatermarkSuccessReport";
 import { api } from "../../../api";
+import NoiseReport from "../../../components/Report/NoiseReport";
 
 
 function NoisePanelReport() {
@@ -35,8 +35,8 @@ function NoisePanelReport() {
   if (loading) return <p className="text-white-100 text-center mt-10">불러오는 중...</p>;
   if (!results) return null;
 
-  return (<></>
-    //<WatermarkReport result={results} confirmMessage={null} />
+  return (
+    <NoiseReport data={results} confirmMessage={null} />
   )
 }
 export default NoisePanelReport;

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -13,6 +13,7 @@ import EditProfile from "../pages/Mypage/EditProfile";
 import Withdraw from "../pages/Mypage/Withdraw";
 import DeepfakePanelReport from "../pages/Mypage/Panel/DeepfakePanelReport";
 import WatermarkPanelReport from "../pages/Mypage/Panel/WatermarkPanelReport";
+import NoisePanelReport from "../pages/Mypage/Panel/NoisePanelReport";
 import Detection from "../pages/Deepfake/Detection";
 import WatermarkInsert from "../pages/Watermark/WatermarkInsert";
 import WatermarkDetection from "../pages/Watermark/WatermarkDetection";
@@ -90,6 +91,10 @@ const Router = createBrowserRouter([
       {
         path: '/mypage/watermark/:id',
         element: <WatermarkPanelReport />
+      },
+      {
+        path: '/mypage/noise/:id',
+        element: <NoisePanelReport />
       },
       {
         path: '/detection',


### PR DESCRIPTION
## 📝 Summary
> - 적대적 노이즈 개별기록 API연결하고 결과화면 공통컴포넌트로 수정했습니다.
> - 적대적 노이즈에 정밀모드 UI 추가했습니다.

## 💻 Describe your changes
1. components\Report\NoiseReport.tsx
노이즈 보고서 화면 공통 컴포넌트로 만들었습니다. 
- data는: API로 받아오는 결과값들
- confirmMessage: '마이페이지에서 확인가능합니다' 멘트용
- showXButton: 마이페이지용 뒤로 가기 버튼(탐지는 false, 마이페이지는 true)

<img width="1918" height="932" alt="스크린샷 2025-08-22 050051" src="https://github.com/user-attachments/assets/3effbdfc-41b8-4903-8e1b-18aa176df6e5" />

2. components\Upload\AdversarialNoise\NoiseOptionPanel.tsx
노이즈 탐지할 때 강도 선택할 수 있는 상세옵션 컴포넌트
 
3. components\Upload\AdversarialNoise\NoiseSetting.tsx
부모 컨테이너 (모드 전환 + 옵션 표시 제어)
-> 모드 전환 : ModeSelector.tsx
-> 옵션 표시 NoiseOptionpanel.tsx
<img width="1722" height="709" alt="스크린샷 2025-08-22 053309" src="https://github.com/user-attachments/assets/eba70fc5-6262-46cc-a0da-47fcdeb677f6" />

4. pages\AdversarialNoise\AdversarialNoise.tsx
FileUploadPage -> DeepfakeFileUpload로 변경

5. pages\AdversarialNoise\NoiseResult.tsx
NoiseReport 컴포넌트 연결로 수정

6. pages\Mypage\Panel\NoisePanelReport.tsx
마이페이지 개별기록 보고서 페이지

7. components\Upload\deepfake\ModeOptions.ts
```
export interface NoiseOptions {
  level : 1 | 2 | 3 | 4 ;
}
```
강도 선택 이름 level로 설정해놓았습니다.
## #️⃣ Issue number and link
> #37 

## 💬 Message to the Reviewer
> 결과페이지 공통컴포넌트로 바꾼 다음 탐지 후에 화면에 렌더 잘 되는지 확인 못해서 확인 부탁드립니다.
>현재 적대적노이즈 플라스크에서 코드변경 있는 듯하여 결과값에 null값이 많아서 100%테스트 못해봤습니다. 신뢰도, 적대적 노이즈 강도 단계, 사진 다운로드 잘 되는지 추후 테스트 부탁드립니다!
> 이미지 업로드 화면을 모드 선택으로 디자인 수정하면서 업로드 화면이 살짝 작아졌습니다.
